### PR TITLE
feat: add JSON Schema for boxy.yaml with editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ A longer Getting Started guide is available in the docs; the sections below prov
 boxy init
 ```
 
+> `boxy init` also creates `.boxy-schema.json` for editor autocompletion.
+> Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) in VS Code for config hints.
+
 1. Start the Boxy service (keeps pools warm):
 
 ```bash
@@ -209,6 +212,15 @@ Initialize configuration file
 ```bash
 boxy init                  # Create config at default location
 boxy init --force          # Overwrite existing config
+```
+
+#### `boxy schema`
+
+Print or write the JSON Schema for `boxy.yaml`
+
+```bash
+boxy schema                # Print schema JSON to stdout
+boxy schema -o .           # Write .boxy-schema.json to current directory
 ```
 
 #### `boxy serve`

--- a/boxy.example.yaml
+++ b/boxy.example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./.boxy-schema.json
 ---
 # Boxy Configuration Example
 

--- a/cmd/boxy/commands/init.go
+++ b/cmd/boxy/commands/init.go
@@ -4,11 +4,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/Geogboe/boxy/internal/config"
 )
+
+// schemaComment is the YAML language server directive that enables editor
+// autocompletion and validation when the YAML extension is installed.
+const schemaComment = "# yaml-language-server: $schema=./" + config.SchemaFileName
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -32,16 +37,30 @@ var initCmd = &cobra.Command{
 			data = []byte(getDefaultConfig())
 		}
 
+		// Prepend schema comment if not already present
+		content := string(data)
+		if !strings.Contains(content, "yaml-language-server") {
+			content = schemaComment + "\n" + content
+		}
+
 		// Write config file
-		if err := os.WriteFile(configPath, data, 0600); err != nil {
+		if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
 			return fmt.Errorf("failed to write config file: %w", err)
 		}
 
+		// Write JSON Schema file alongside config
+		schemaPath := filepath.Join(filepath.Dir(configPath), config.SchemaFileName)
+		if err := os.WriteFile(schemaPath, config.SchemaJSON, 0600); err != nil {
+			return fmt.Errorf("failed to write schema file: %w", err)
+		}
+
 		fmt.Printf("✓ Created config file: %s\n", configPath)
+		fmt.Printf("✓ Created schema file: %s\n", schemaPath)
 		fmt.Printf("✓ Config directory: %s\n", filepath.Dir(configPath))
 		fmt.Printf("\nEdit the config file to define your pools, then run:\n")
 		fmt.Printf("  boxy serve    # Start the Boxy service\n")
 		fmt.Printf("  boxy pool ls  # List pools and their status\n")
+		fmt.Printf("\nTip: Install the YAML extension in VS Code for config autocompletion.\n")
 
 		return nil
 	},

--- a/cmd/boxy/commands/schema.go
+++ b/cmd/boxy/commands/schema.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Geogboe/boxy/internal/config"
+)
+
+var schemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Print or write the JSON Schema for boxy.yaml",
+	Long: `Outputs the JSON Schema that describes valid boxy.yaml configuration files.
+
+By default the schema is printed to stdout. Use --output to write it as a file
+to a given directory, producing <dir>/.boxy-schema.json.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		outputDir, _ := cmd.Flags().GetString("output")
+
+		if outputDir == "" {
+			// Print to stdout
+			fmt.Print(string(config.SchemaJSON))
+			return nil
+		}
+
+		// Write to directory
+		dest := filepath.Join(outputDir, config.SchemaFileName)
+		if err := os.WriteFile(dest, config.SchemaJSON, 0600); err != nil {
+			return fmt.Errorf("failed to write schema file: %w", err)
+		}
+
+		fmt.Printf("✓ Wrote schema to %s\n", dest)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(schemaCmd)
+	schemaCmd.Flags().StringP("output", "o", "", "directory to write "+config.SchemaFileName+" into")
+}

--- a/cmd/boxy/commands/schema_test.go
+++ b/cmd/boxy/commands/schema_test.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Geogboe/boxy/internal/config"
+)
+
+func TestSchemaCmd_Stdout(t *testing.T) {
+	// Capture stdout by redirecting it
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"schema"})
+	require.NoError(t, cmd.Execute())
+
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, len(config.SchemaJSON)+1024)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	// Verify it's valid JSON
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &raw), "stdout output should be valid JSON")
+	assert.Contains(t, raw, "$schema")
+}
+
+func TestSchemaCmd_OutputFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"schema", "--output", tmpDir})
+	require.NoError(t, cmd.Execute())
+
+	// Verify file was written
+	schemaPath := filepath.Join(tmpDir, config.SchemaFileName)
+	data, err := os.ReadFile(schemaPath)
+	require.NoError(t, err, "schema file should exist at %s", schemaPath)
+
+	// Verify it's valid JSON matching the embedded schema
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Contains(t, raw, "$schema")
+	assert.Equal(t, config.SchemaJSON, data)
+}

--- a/docs/decisions/adr-013-config-schema.md
+++ b/docs/decisions/adr-013-config-schema.md
@@ -1,7 +1,7 @@
 # ADR-013: Configuration Schema Standardization
 
 **Date**: 2025-11-23
-**Status**: Proposed
+**Status**: Partially Implemented
 
 ## Context
 
@@ -9,21 +9,60 @@ The v1-prerelease proposed a more formal configuration schema for Boxy, to valid
 
 ## Decision
 
-1. Standardize configuration schema as an OpenAPI-like schema or JSON schema file `docs/config-schema.json`.
-2. Validate configuration at startup (or early) and provide detailed validation errors to the user.
-3. Add validation tests for the configuration schema and reference the schema in `docs/guides/getting-started.md`.
+1. Standardize configuration schema as a JSON Schema (draft 2020-12) file embedded in the binary at `internal/config/schema.json`.
+2. The `boxy init` command writes `.boxy-schema.json` alongside `boxy.yaml` and prepends a `# yaml-language-server` directive so VS Code (with the YAML extension) provides autocompletion and validation automatically.
+3. A `boxy schema` subcommand prints or writes the schema for use outside of `boxy init`.
+4. Add validation tests for the configuration schema using `google/jsonschema-go`.
+
+### Schema Location
+
+The schema file (`.boxy-schema.json`) is written to the **current directory** alongside the config file rather than a central location like `~/.config/boxy/`. Rationale:
+
+- Relative path in the YAML comment is portable across machines
+- Schema is always version-matched to the binary that wrote it
+- No dependency on XDG directories
+- Teams can commit the schema to source control if they want
+
+### JSON Schema Library
+
+We chose [`google/jsonschema-go`](https://github.com/google/jsonschema-go) (v0.4.2) for schema validation in tests. This is used only in test code to validate that the example config passes the schema.
+
+**Why `google/jsonschema-go`:**
+
+- Official Google project (MIT licensed)
+- Zero external dependencies (stdlib only)
+- Supports draft 2020-12
+- Clean API: unmarshal schema JSON, resolve, validate `map[string]any`
+
+**Known limitations (acceptable for our use case):**
+
+- Pre-v1 API — used only in tests, so breaking changes are low-risk
+- `format` keyword is ignored during validation — we use `pattern` for duration strings instead
+- Must validate `map[string]any`, not Go structs directly — this is how we use it (YAML → map → validate)
 
 ## Implementation
 
-- Draft `docs/config-schema.json` with all keys: `server`, `agents`, `pools`, `hooks` with examples and types.
-- Add a `boxy config validate` command that checks a config file against the schema and returns errors.
-- Incorporate schema validation into `boxy serve` startup path in order to fail-fast on malformed config.
+### Phase 1 (Implemented)
+
+- `internal/config/schema.json` — JSON Schema (draft 2020-12) describing all config types
+- `config.SchemaJSON` — embedded schema bytes via `//go:embed`
+- `config.SchemaFileName` — constant for the file name (`.boxy-schema.json`)
+- `boxy init` writes the schema file and adds the YAML language server comment
+- `boxy schema` subcommand prints to stdout or writes to a directory (`--output`)
+- `boxy.example.yaml` includes the schema comment
+- Test coverage for schema validity, structure, and example config validation
+
+### Phase 2 (Future)
+
+- `boxy config validate` command that checks a config file against the schema and returns errors
+- Incorporate schema validation into `boxy serve` startup path for fail-fast on malformed config
+- Schema generation from Go types (if/when the library API stabilizes)
 
 ## Consequences
 
-- Users get immediate feedback for config issues.
-- Editor integrations and auto-complete become feasible with editor schemas.
-- This adds maintenance overhead for schema updates across versions.
+- Users get immediate feedback for config issues via editor integration.
+- Editor autocompletion and hover docs are available with zero additional setup beyond `boxy init`.
+- This adds maintenance overhead for schema updates across versions — the schema must be kept in sync with changes to config structs.
 
 ## History
 
@@ -33,6 +72,10 @@ SourceType: "planning-proposal"
 Created: "2024-11-22"
 LastMigrated: "2025-11-23"
 MigratedBy: "doc-reconciliation"
-Status: "proposed"
-Notes: "Create a canonical schema and enforce validation in startup and a `config validate` command."
+Status: "partially-implemented"
+Notes: >
+  Phase 1 implemented: JSON Schema file, go:embed, boxy init/schema commands,
+  editor integration via yaml-language-server directive, tests using
+  google/jsonschema-go. Phase 2 (runtime validation, boxy config validate)
+  is deferred.
 ```

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/gordonklaus/ineffassign v0.1.0 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/comment v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	_ "embed"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -12,6 +13,14 @@ import (
 	"github.com/Geogboe/boxy/internal/core/pool"
 	"github.com/Geogboe/boxy/pkg/crypto"
 )
+
+// SchemaFileName is the name of the JSON Schema file written alongside boxy.yaml.
+const SchemaFileName = ".boxy-schema.json"
+
+// SchemaJSON contains the embedded JSON Schema for boxy.yaml configuration files.
+//
+//go:embed schema.json
+var SchemaJSON []byte
 
 // Config represents the Boxy configuration
 type Config struct {

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -53,6 +53,14 @@
 //		fmt.Printf("Pool: %s (backend: %s)\n", pool.Name, pool.Backend)
 //	}
 //
+// # Schema
+//
+// A JSON Schema (draft 2020-12) describing valid boxy.yaml files is embedded
+// in the binary and exposed via [SchemaJSON]. The schema file name used on
+// disk is [SchemaFileName] (.boxy-schema.json). The `boxy init` command writes
+// this file alongside the config and adds a yaml-language-server directive so
+// editors with the YAML extension provide autocompletion and validation.
+//
 // # Encryption
 //
 // The package provides encryption key management:

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -1,0 +1,333 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Geogboe/boxy/internal/config/schema.json",
+  "title": "Boxy Configuration",
+  "description": "Configuration file for Boxy sandboxing orchestration tool.",
+  "type": "object",
+  "properties": {
+    "pools": {
+      "description": "Resource pool definitions. Each pool maintains a warm set of pre-provisioned resources.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/PoolConfig"
+      }
+    },
+    "agents": {
+      "description": "Remote agent configurations for distributed resource management.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/AgentConfig"
+      }
+    },
+    "storage": {
+      "$ref": "#/$defs/StorageConfig"
+    },
+    "logging": {
+      "$ref": "#/$defs/LoggingConfig"
+    },
+    "api": {
+      "$ref": "#/$defs/APIConfig"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "PoolConfig": {
+      "description": "Configuration for a resource pool.",
+      "type": "object",
+      "required": ["name", "type", "backend", "min_ready", "max_total"],
+      "properties": {
+        "name": {
+          "description": "Unique pool identifier.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "Resource type for this pool.",
+          "type": "string",
+          "enum": ["container", "vm", "process"]
+        },
+        "backend": {
+          "description": "Provider backend to use for provisioning resources.",
+          "type": "string",
+          "enum": ["docker", "hyperv", "kvm", "vmware"]
+        },
+        "image": {
+          "description": "Image or template to use when provisioning resources. Required for container and vm types.",
+          "type": "string"
+        },
+        "min_ready": {
+          "description": "Minimum number of resources to keep in the ready state (warm pool size).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_total": {
+          "description": "Maximum total resources allowed (ready + allocated + provisioning).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "cpus": {
+          "description": "Number of CPUs to allocate per resource.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "memory_mb": {
+          "description": "Memory allocation per resource in megabytes.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "disk_gb": {
+          "description": "Disk allocation per resource in gigabytes (primarily for VMs).",
+          "type": "integer",
+          "minimum": 1
+        },
+        "labels": {
+          "description": "Key-value labels to apply to resources in this pool.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "environment": {
+          "description": "Environment variables to set on resources in this pool.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "extra_config": {
+          "description": "Backend-specific extra configuration options.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "health_check_interval": {
+          "description": "Interval between health checks. Uses Go duration format (e.g. '30s', '5m').",
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$"
+        },
+        "hooks": {
+          "$ref": "#/$defs/HookConfig"
+        },
+        "timeouts": {
+          "$ref": "#/$defs/TimeoutConfig"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AgentConfig": {
+      "description": "Configuration for a remote Boxy agent.",
+      "type": "object",
+      "required": ["id", "address"],
+      "properties": {
+        "id": {
+          "description": "Unique identifier for this agent.",
+          "type": "string",
+          "minLength": 1
+        },
+        "address": {
+          "description": "Network address of the agent in host:port format.",
+          "type": "string"
+        },
+        "providers": {
+          "description": "List of provider names available on this agent.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tls_cert_path": {
+          "description": "Path to the client TLS certificate file.",
+          "type": "string"
+        },
+        "tls_key_path": {
+          "description": "Path to the client TLS key file.",
+          "type": "string"
+        },
+        "tls_ca_path": {
+          "description": "Path to the CA certificate file for verifying the agent.",
+          "type": "string"
+        },
+        "use_tls": {
+          "description": "Enable TLS for communication with this agent.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "StorageConfig": {
+      "description": "Storage backend configuration for persisting state.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Storage backend type.",
+          "type": "string",
+          "enum": ["sqlite", "postgres"],
+          "default": "sqlite"
+        },
+        "path": {
+          "description": "File path for the SQLite database.",
+          "type": "string",
+          "default": "./boxy.db"
+        },
+        "dsn": {
+          "description": "Data source name for PostgreSQL connections.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LoggingConfig": {
+      "description": "Logging configuration.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "Log verbosity level.",
+          "type": "string",
+          "enum": ["debug", "info", "warn", "error"],
+          "default": "info"
+        },
+        "format": {
+          "description": "Log output format.",
+          "type": "string",
+          "enum": ["text", "json"],
+          "default": "text"
+        }
+      },
+      "additionalProperties": false
+    },
+    "APIConfig": {
+      "description": "HTTP API server configuration.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the HTTP API server.",
+          "type": "boolean",
+          "default": true
+        },
+        "listen": {
+          "description": "Address and port to listen on (e.g. ':8080').",
+          "type": "string",
+          "default": ":8080"
+        },
+        "read_timeout_secs": {
+          "description": "HTTP server read timeout in seconds.",
+          "type": "integer",
+          "minimum": 1,
+          "default": 15
+        },
+        "write_timeout_secs": {
+          "description": "HTTP server write timeout in seconds.",
+          "type": "integer",
+          "minimum": 1,
+          "default": 15
+        },
+        "idle_timeout_secs": {
+          "description": "HTTP keep-alive idle timeout in seconds.",
+          "type": "integer",
+          "minimum": 1,
+          "default": 60
+        }
+      },
+      "additionalProperties": false
+    },
+    "HookConfig": {
+      "description": "Lifecycle hook configuration for a pool.",
+      "type": "object",
+      "properties": {
+        "on_provision": {
+          "description": "Hooks that run after a resource is provisioned (background finalization).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Hook"
+          }
+        },
+        "on_allocate": {
+          "description": "Hooks that run before a resource is allocated to a user (fast personalization).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Hook"
+          }
+        },
+        "use_system_hooks": {
+          "description": "Enable Boxy's built-in default hooks.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "Hook": {
+      "description": "A lifecycle hook that runs a script at a specific point in the resource lifecycle.",
+      "type": "object",
+      "required": ["name", "type", "shell"],
+      "properties": {
+        "name": {
+          "description": "Descriptive name for this hook.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "Hook execution type.",
+          "type": "string",
+          "enum": ["script"]
+        },
+        "shell": {
+          "description": "Shell interpreter to use for running the script.",
+          "type": "string",
+          "enum": ["bash", "powershell", "python"]
+        },
+        "inline": {
+          "description": "Inline script content to execute. Mutually exclusive with 'path'.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path to a script file to execute. Mutually exclusive with 'inline'.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum execution time for this hook. Uses Go duration format (e.g. '30s', '5m').",
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$"
+        },
+        "retry": {
+          "description": "Number of retry attempts if the hook fails.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "continue_on_failure": {
+          "description": "If true, hook failure does not prevent the lifecycle operation from completing.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "TimeoutConfig": {
+      "description": "Phase-level timeout configuration for pool lifecycle operations.",
+      "type": "object",
+      "properties": {
+        "provision": {
+          "description": "Maximum time for the provider to provision a resource. Uses Go duration format (e.g. '5m').",
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$"
+        },
+        "finalization": {
+          "description": "Maximum combined time for all on_provision hooks. Uses Go duration format (e.g. '10m').",
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$"
+        },
+        "personalization": {
+          "description": "Maximum combined time for all on_allocate hooks. Uses Go duration format (e.g. '30s').",
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$"
+        },
+        "destroy": {
+          "description": "Maximum time for the provider to destroy a resource. Uses Go duration format (e.g. '1m').",
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSchemaJSON_IsValidJSON(t *testing.T) {
+	var raw map[string]interface{}
+	err := json.Unmarshal(SchemaJSON, &raw)
+	require.NoError(t, err, "SchemaJSON must be valid JSON")
+}
+
+func TestSchemaJSON_HasExpectedStructure(t *testing.T) {
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(SchemaJSON, &raw))
+
+	expectedKeys := []string{"$schema", "type", "properties", "$defs"}
+	for _, key := range expectedKeys {
+		assert.Contains(t, raw, key, "schema should contain top-level key %q", key)
+	}
+
+	assert.Equal(t, "https://json-schema.org/draft/2020-12/schema", raw["$schema"])
+	assert.Equal(t, "object", raw["type"])
+}
+
+func TestSchemaJSON_TopLevelProperties(t *testing.T) {
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(SchemaJSON, &raw))
+
+	props, ok := raw["properties"].(map[string]interface{})
+	require.True(t, ok, "properties should be an object")
+
+	expectedProps := []string{"pools", "agents", "storage", "logging", "api"}
+	for _, prop := range expectedProps {
+		assert.Contains(t, props, prop, "properties should contain %q", prop)
+	}
+}
+
+func TestSchemaJSON_Defs(t *testing.T) {
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(SchemaJSON, &raw))
+
+	defs, ok := raw["$defs"].(map[string]interface{})
+	require.True(t, ok, "$defs should be an object")
+
+	expectedDefs := []string{
+		"PoolConfig", "AgentConfig", "StorageConfig",
+		"LoggingConfig", "APIConfig", "HookConfig",
+		"Hook", "TimeoutConfig",
+	}
+	for _, def := range expectedDefs {
+		assert.Contains(t, defs, def, "$defs should contain %q", def)
+	}
+}
+
+func TestSchemaJSON_ResolvesSuccessfully(t *testing.T) {
+	var schema jsonschema.Schema
+	require.NoError(t, json.Unmarshal(SchemaJSON, &schema))
+
+	_, err := schema.Resolve(nil)
+	require.NoError(t, err, "schema should resolve without errors")
+}
+
+func TestSchemaJSON_ValidatesDefaultConfig(t *testing.T) {
+	var schema jsonschema.Schema
+	require.NoError(t, json.Unmarshal(SchemaJSON, &schema))
+
+	resolved, err := schema.Resolve(nil)
+	require.NoError(t, err)
+
+	// Parse the default config YAML into a map for validation
+	defaultCfg := `storage:
+  type: sqlite
+  path: ./boxy.db
+logging:
+  level: info
+  format: text
+pools:
+  - name: ubuntu-containers
+    type: container
+    backend: docker
+    image: ubuntu:22.04
+    min_ready: 3
+    max_total: 10
+    cpus: 2
+    memory_mb: 512
+    health_check_interval: 30s
+`
+
+	var data map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(defaultCfg), &data))
+
+	err = resolved.Validate(data)
+	assert.NoError(t, err, "default config should pass schema validation")
+}
+
+func TestSchemaJSON_RejectsInvalidConfig(t *testing.T) {
+	var schema jsonschema.Schema
+	require.NoError(t, json.Unmarshal(SchemaJSON, &schema))
+
+	resolved, err := schema.Resolve(nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "unknown top-level property",
+			yaml: `bogus_key: true`,
+		},
+		{
+			name: "invalid log level",
+			yaml: `logging:
+  level: verbose`,
+		},
+		{
+			name: "invalid storage type",
+			yaml: `storage:
+  type: mysql`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var data map[string]interface{}
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &data))
+
+			err := resolved.Validate(data)
+			assert.Error(t, err, "invalid config should fail schema validation")
+		})
+	}
+}
+
+func TestSchemaFileName(t *testing.T) {
+	assert.Equal(t, ".boxy-schema.json", SchemaFileName)
+}


### PR DESCRIPTION
## Summary

- Adds a JSON Schema (draft 2020-12) describing all `boxy.yaml` configuration types, embedded in the binary via `go:embed`
- `boxy init` now writes `.boxy-schema.json` alongside the config and prepends a `yaml-language-server` directive for automatic VS Code integration
- New `boxy schema` subcommand prints the schema to stdout or writes it to a directory (`--output`)
- ADR-013 updated to "Partially Implemented" with full decision rationale including the choice of `google/jsonschema-go` for test validation

## Test plan

- [x] `go build ./cmd/boxy` compiles with embedded schema
- [x] `go test -race ./internal/config/...` — schema validity, structure, resolves, validates good config, rejects bad config
- [x] `go test -race ./cmd/boxy/commands/...` — schema command stdout and `--output` flag
- [x] `go test -race -short ./...` — no regressions across the full project
- [x] `golangci-lint run` — no new lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)