### PR TITLE
chore: update golangci action for node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: "1.25"
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9.2.0
         with:
           version: latest
           only-new-issues: true


### PR DESCRIPTION
## Summary
- update golangci/golangci-lint-action from v7 to v9.2.0

## Goal
Remove the remaining CI Node 20 deprecation warning now that checkout and setup-go are already on Node 24.
