### PR TITLE
chore: add deny-all permissions baseline to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+permissions: {}
+
 jobs:
   release-please:
     name: Release Please


### PR DESCRIPTION
## Summary
- Add `permissions: {}` at workflow level in `release.yml` so the default token has no permissions
- Each job already declares only what it needs (`contents: write`, `pull-requests: write`)
- Repo-level default workflow permissions also flipped to `read` via Settings > Actions

Refs #55

## Test plan
- [ ] CI passes
- [ ] Release Please still creates release PRs (has explicit `contents: write` + `pull-requests: write`)
- [ ] GoReleaser still uploads assets on release (has explicit `contents: write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)