### PR TITLE
feat(api): add async sandbox fulfillment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,13 @@ docs/adr/             # Architecture Decision Records
 
 - Pools are homogeneous inventories of resources (see `pkg/model/pool.go` and `pkg/model/resource_collection.go`).
 - **Resources are single-use:** when a resource is allocated into a sandbox, it is never returned to a pool. (ADR-0002)
+- The daemon reconcile loop runs pool reconciliation both before and after sandbox fulfillment so preheat targets are restored in the same tick after allocations drain a pool.
 
 ### Sandboxes
 
 - A sandbox is an environment that can be as small as a single resource or as large as a full lab.
+- Sandbox creation via the REST API is asynchronous: `POST /api/v1/sandboxes` persists a sandbox request in `pending`, the daemon fulfillment loop provisions/allocates resources, and the sandbox transitions to `ready` or `failed`.
+- `boxy serve` persists runtime state in `.boxy/state.json` next to the active config (or under the working directory when no config file is used), so accepted async sandbox requests survive normal daemon restarts.
 - Preferred phrasing when describing compositions:
   - "container sandbox" (1 container)
   - "3 VM lab sandbox" (multi-VM lab)
@@ -111,6 +114,7 @@ Wrap repeated commands in `Taskfile.yml`. If a command is run more than once, ad
 
 - `gopls` is available locally for code navigation, refactoring, and linting.
 - `task` (go-task) for running project commands.
+- `task lint` mirrors CI by running `golangci-lint` v2 from source via `go run`, so it does not depend on a preinstalled local binary version.
 - GoReleaser is pinned in the isolated `tools/` module; use `task release:check` and `task release:snapshot` instead of assuming a global `goreleaser` binary is installed.
 
 ## Installer Notes

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Boxy keeps pools of generic, ready-to-use resources warm ahead of time. When a u
 
 **Pool** — A named, homogeneous inventory of pre-provisioned resources. Declared in config. Each pool carries its own provisioning config (`type` identifies the provider/driver, `config` is a driver-interpreted opaque blob) and policy (preheat, recycle). The pool IS the spec — there is no separate "blueprint", "template", or "spec" entity.
 
-**Sandbox** — A user-facing environment containing 1..N resources drawn from pools. Sandbox classes are defined in separate `.sandbox.yaml` files and instantiated via CLI. When resources move from pool to sandbox, post-allocation hooks run to personalize them (set credentials, configure networking, etc.). Boxy returns connection info to the user; it is not a proxy.
+**Sandbox** — A user-facing environment containing 1..N resources drawn from pools. Sandbox creation is asynchronous on the server: the API persists a sandbox request in `pending`, the reconcile loop fulfills it, and the sandbox transitions to `ready` or `failed`. When resources move from pool to sandbox, post-allocation hooks run to personalize them (set credentials, configure networking, etc.). Boxy returns connection info to the user; it is not a proxy.
 
 **Provider** — An external system that provides resources (Docker, Hyper-V, Podman, VMware, etc.). Providers have a type that maps to a driver. Provider connection details (socket, host, certs) are owned by the agent, not the server. Drivers auto-discover their environment where possible.
 
@@ -130,9 +130,30 @@ When a resource moves from a pool into a sandbox, hooks run to personalize it:
 
 Resources in pools are intentionally generic (no specific user, no credentials). Hooks make them specific at allocation time. This means credentials don't exist until allocation — they are generated/set by the hook and returned as connection info.
 
+### Async Sandbox API Flow
+
+Sandbox creation is a server-side async workflow:
+
+1. Client `POST`s a sandbox request to `/api/v1/sandboxes`
+2. Server persists the sandbox and returns `202 Accepted` with `status: "pending"`
+3. The daemon reconcile loop provisions and allocates resources
+4. Client polls `GET /api/v1/sandboxes/{id}` until status becomes `ready` or `failed`
+
+The create API uses resource requests rather than allocated resource IDs:
+
+```json
+{
+  "name": "pentest-lab",
+  "requests": [
+    {"type": "container", "profile": "kali", "count": 3},
+    {"type": "container", "profile": "ubuntu-targets", "count": 1}
+  ]
+}
+```
+
 ### Sandbox Access Model
 
-Boxy is not a proxy. When a sandbox is created, Boxy returns connection info for each resource:
+Boxy is not a proxy. When a sandbox reaches `ready`, Boxy returns connection info for each resource:
 - SSH host/port/key for Linux VMs
 - RDP address for Windows VMs
 - SMB path for file shares

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -83,7 +83,7 @@ tasks:
       - lint:go
       - golangci-lint
     cmds:
-      - golangci-lint run ./...
+      - go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...
 
   release:check:
     desc: Validate GoReleaser config using the pinned tools module

--- a/docs/cli-wireframe.md
+++ b/docs/cli-wireframe.md
@@ -75,12 +75,14 @@ boxy
 │   ├── list                                     List all sandboxes
 │   │
 │   │   $ boxy sandbox list
-│   │     [JSON array of sandboxes]
+│   │     ID         NAME         STATUS       RESOURCES
+│   │     sb-a1b2c3  pentest-lab  ready        3
+│   │     sb-d4e5f6  warmup-lab   pending      0
 │   │
 │   ├── get <id>                                 Get sandbox details
 │   │
 │   │   $ boxy sandbox get sb-a1b2c3
-│   │     [JSON object]
+│   │     {"id":"sb-a1b2c3","name":"pentest-lab","status":"ready",...}
 │   │
 │   └── delete <id>                              Delete a sandbox
 │

--- a/internal/cli/sandbox_create.go
+++ b/internal/cli/sandbox_create.go
@@ -169,8 +169,13 @@ func sandboxCreate(ctx context.Context, opts sandboxCreateOpts) error {
 	for _, req := range spec.Resources {
 		sb, err = sm.AddFromPool(ctx, sb.ID, model.PoolName(req.Pool), req.Count)
 		if err != nil {
-			return err
+			return failLocalSandboxCreate(ctx, st, sb.ID, err)
 		}
+	}
+	sb.Status = model.SandboxStatusReady
+	sb.Error = ""
+	if err := st.PutSandbox(ctx, sb); err != nil {
+		return failLocalSandboxCreate(ctx, st, sb.ID, fmt.Errorf("put sandbox %q: %w", sb.ID, err))
 	}
 	doneAllocate(fmt.Sprintf("%s  ·  %d resource(s)", sb.ID, len(sb.Resources)))
 
@@ -208,6 +213,26 @@ func sandboxCreate(ctx context.Context, opts sandboxCreateOpts) error {
 	pterm.Println()
 
 	return nil
+}
+
+func failLocalSandboxCreate(ctx context.Context, st store.Store, sandboxID model.SandboxID, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	if st == nil || sandboxID == "" {
+		return cause
+	}
+
+	sb, err := st.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return cause
+	}
+	sb.Status = model.SandboxStatusFailed
+	sb.Error = cause.Error()
+	if putErr := st.PutSandbox(ctx, sb); putErr != nil {
+		return fmt.Errorf("%w (also failed to mark sandbox %q failed: %v)", cause, sandboxID, putErr)
+	}
+	return cause
 }
 
 // printConnectionInfo displays sandbox connection info once to the terminal.

--- a/internal/cli/sandbox_create_test.go
+++ b/internal/cli/sandbox_create_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+func TestFailLocalSandboxCreate_MarksSandboxFailed(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "local",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "web", Count: 1}},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+
+	cause := failLocalSandboxCreate(ctx, st, sb.ID, context.DeadlineExceeded)
+	if cause == nil {
+		t.Fatal("expected original cause to be returned")
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusFailed {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusFailed)
+	}
+	if !strings.Contains(got.Error, context.DeadlineExceeded.Error()) {
+		t.Fatalf("error = %q, want %q", got.Error, context.DeadlineExceeded)
+	}
+}
+
+func TestFailLocalSandboxCreate_LeavesMissingSandboxAlone(t *testing.T) {
+	t.Parallel()
+
+	err := failLocalSandboxCreate(context.Background(), store.NewMemoryStore(), "missing", context.DeadlineExceeded)
+	if err == nil {
+		t.Fatal("expected original cause to be returned")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("error = %q, want original cause", err)
+	}
+}

--- a/internal/cli/sandbox_get.go
+++ b/internal/cli/sandbox_get.go
@@ -12,10 +12,13 @@ import (
 // It embeds the sandbox and includes full Resource objects (with Properties)
 // so callers can access allocation-time connection info after the fact.
 type sandboxGetOutput struct {
-	ID        model.SandboxID       `json:"id"`
-	Name      string                `json:"name"`
-	Policies  model.SandboxPolicies `json:"policies"`
-	Resources []model.Resource      `json:"resources"`
+	ID        model.SandboxID         `json:"id"`
+	Name      string                  `json:"name"`
+	Policies  model.SandboxPolicies   `json:"policies"`
+	Status    model.SandboxStatus     `json:"status"`
+	Requests  []model.ResourceRequest `json:"requests,omitempty"`
+	Error     string                  `json:"error,omitempty"`
+	Resources []model.Resource        `json:"resources"`
 }
 
 func newSandboxGetCommand(serverAddr func() string) *cobra.Command {
@@ -53,6 +56,9 @@ func newSandboxGetCommand(serverAddr func() string) *cobra.Command {
 				ID:        sb.ID,
 				Name:      sb.Name,
 				Policies:  sb.Policies,
+				Status:    sb.Status,
+				Requests:  sb.Requests,
+				Error:     sb.Error,
 				Resources: resources,
 			})
 		},

--- a/internal/cli/sandbox_list.go
+++ b/internal/cli/sandbox_list.go
@@ -30,11 +30,12 @@ func newSandboxListCommand(serverAddr func() string) *cobra.Command {
 				pterm.Println("  No sandboxes found.")
 				return nil
 			}
-			rows := [][]string{{"ID", "NAME", "RESOURCES"}}
+			rows := [][]string{{"ID", "NAME", "STATUS", "RESOURCES"}}
 			for _, sb := range sbs {
 				rows = append(rows, []string{
 					string(sb.ID),
 					sb.Name,
+					string(sb.Status),
 					fmt.Sprintf("%d", len(sb.Resources)),
 				})
 			}

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -68,8 +68,8 @@ func newSandboxTestServer(t *testing.T, listItems []model.Sandbox) *httptest.Ser
 	}
 
 	sandboxes := map[string]model.Sandbox{
-		"sb-1": {ID: "sb-1", Name: "one", Resources: []model.ResourceID{"res-1"}},
-		"sb-2": {ID: "sb-2", Name: "two", Resources: []model.ResourceID{"res-1", "res-2"}},
+		"sb-1": {ID: "sb-1", Name: "one", Status: model.SandboxStatusPending, Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "ubuntu-2204", Count: 1}}, Resources: []model.ResourceID{"res-1"}},
+		"sb-2": {ID: "sb-2", Name: "two", Status: model.SandboxStatusReady, Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "ubuntu-2204", Count: 1}, {Type: model.ResourceTypeVM, Profile: "win-2022", Count: 1}}, Resources: []model.ResourceID{"res-1", "res-2"}},
 	}
 	resources := map[string]model.Resource{
 		"res-1": resourceOne,
@@ -151,8 +151,8 @@ func TestSandboxList_empty(t *testing.T) {
 
 func TestSandboxList_with_sandboxes(t *testing.T) {
 	srv := newSandboxTestServer(t, []model.Sandbox{
-		{ID: "sb-1", Name: "one", Resources: []model.ResourceID{"res-1"}},
-		{ID: "sb-2", Name: "two", Resources: []model.ResourceID{"res-1", "res-2"}},
+		{ID: "sb-1", Name: "one", Status: model.SandboxStatusPending, Resources: []model.ResourceID{"res-1"}},
+		{ID: "sb-2", Name: "two", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1", "res-2"}},
 	})
 	defer srv.Close()
 
@@ -165,7 +165,7 @@ func TestSandboxList_with_sandboxes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	for _, want := range []string{"sb-1", "one", "sb-2", "two", "2"} {
+	for _, want := range []string{"sb-1", "one", "pending", "sb-2", "two", "ready", "2"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output = %q, want %q", output, want)
 		}
@@ -174,8 +174,8 @@ func TestSandboxList_with_sandboxes(t *testing.T) {
 
 func TestSandboxGet_found(t *testing.T) {
 	srv := newSandboxTestServer(t, []model.Sandbox{
-		{ID: "sb-1", Name: "one", Resources: []model.ResourceID{"res-1"}},
-		{ID: "sb-2", Name: "two", Resources: []model.ResourceID{"res-1", "res-2"}},
+		{ID: "sb-1", Name: "one", Status: model.SandboxStatusPending, Resources: []model.ResourceID{"res-1"}},
+		{ID: "sb-2", Name: "two", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1", "res-2"}},
 	})
 	defer srv.Close()
 
@@ -188,7 +188,7 @@ func TestSandboxGet_found(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	for _, want := range []string{`"id": "sb-2"`, `"name": "two"`, `"security_profile": "lab"`, `"id": "res-1"`, `"id": "res-2"`} {
+	for _, want := range []string{`"id": "sb-2"`, `"name": "two"`, `"status": "ready"`, `"security_profile": "lab"`, `"profile": "ubuntu-2204"`, `"id": "res-1"`, `"id": "res-2"`} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output = %q, want %q", output, want)
 		}
@@ -197,8 +197,8 @@ func TestSandboxGet_found(t *testing.T) {
 
 func TestSandboxGet_not_found(t *testing.T) {
 	srv := newSandboxTestServer(t, []model.Sandbox{
-		{ID: "sb-1", Name: "one", Resources: []model.ResourceID{"res-1"}},
-		{ID: "sb-2", Name: "two", Resources: []model.ResourceID{"res-1", "res-2"}},
+		{ID: "sb-1", Name: "one", Status: model.SandboxStatusPending, Resources: []model.ResourceID{"res-1"}},
+		{ID: "sb-2", Name: "two", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1", "res-2"}},
 	})
 	defer srv.Close()
 
@@ -216,8 +216,8 @@ func TestSandboxGet_not_found(t *testing.T) {
 
 func TestSandboxDelete_found(t *testing.T) {
 	srv := newSandboxTestServer(t, []model.Sandbox{
-		{ID: "sb-1", Name: "one", Resources: []model.ResourceID{"res-1"}},
-		{ID: "sb-2", Name: "two", Resources: []model.ResourceID{"res-1", "res-2"}},
+		{ID: "sb-1", Name: "one", Status: model.SandboxStatusPending, Resources: []model.ResourceID{"res-1"}},
+		{ID: "sb-2", Name: "two", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1", "res-2"}},
 	})
 	defer srv.Close()
 
@@ -237,8 +237,8 @@ func TestSandboxDelete_found(t *testing.T) {
 
 func TestSandboxDelete_not_found(t *testing.T) {
 	srv := newSandboxTestServer(t, []model.Sandbox{
-		{ID: "sb-1", Name: "one", Resources: []model.ResourceID{"res-1"}},
-		{ID: "sb-2", Name: "two", Resources: []model.ResourceID{"res-1", "res-2"}},
+		{ID: "sb-1", Name: "one", Status: model.SandboxStatusPending, Resources: []model.ResourceID{"res-1"}},
+		{ID: "sb-2", Name: "two", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1", "res-2"}},
 	})
 	defer srv.Close()
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -97,7 +97,12 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 		providersMap[p.Name] = p
 	}
 
-	st := store.NewMemoryStore()
+	doneState := ui.step("Opening state")
+	st, statePath, err := openServeStore(cfgPath)
+	if err != nil {
+		return err
+	}
+	doneState(statePath)
 
 	// Drivers + embedded agent
 	doneAgent := ui.step("Starting embedded agent")
@@ -119,6 +124,7 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 	}
 	poolMgr := pool.New(st, provisioner)
 	sandboxMgr := sandbox.New(st, provisioner)
+	sandboxFulfiller := sandbox.NewFulfiller(st, poolMgr, sandboxMgr)
 
 	// Pools
 	donePools := ui.step("Initializing pools")
@@ -148,7 +154,7 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 		return srv.Start(ctx)
 	})
 	g.Go(func() error {
-		return serveLoop(ctx, poolMgr, poolNames, ui)
+		return serveLoop(ctx, poolMgr, sandboxFulfiller, poolNames, ui)
 	})
 
 	printServeBanner(listenAddr, uiEnabled, len(cfg.Pools))
@@ -175,6 +181,30 @@ func resolveUIEnabled(opts serveOpts, cmd *cobra.Command, cfg boxyconfig.Config)
 		return opts.ui
 	}
 	return cfg.Server.UIEnabled()
+}
+
+func openServeStore(cfgPath string) (store.Store, string, error) {
+	statePath, err := serveStatePath(cfgPath)
+	if err != nil {
+		return nil, "", err
+	}
+	st, err := store.NewDiskStore(statePath)
+	if err != nil {
+		return nil, "", err
+	}
+	return st, statePath, nil
+}
+
+func serveStatePath(cfgPath string) (string, error) {
+	if cfgPath != "" {
+		return filepath.Join(filepath.Dir(cfgPath), ".boxy", "state.json"), nil
+	}
+
+	wd, err := effectiveWD()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	return filepath.Join(wd, ".boxy", "state.json"), nil
 }
 
 func loadConfig(explicitPath string) (cfg boxyconfig.Config, usedPath string, _ error) {
@@ -209,7 +239,13 @@ func findDefaultConfigPath() (string, error) {
 	return findConfigPathInDir(wd)
 }
 
-func serveLoop(ctx context.Context, poolMgr *pool.Manager, poolNames []model.PoolName, ui *serveUI) error {
+func serveLoop(
+	ctx context.Context,
+	poolMgr servePoolReconciler,
+	sandboxFulfiller serveSandboxReconciler,
+	poolNames []model.PoolName,
+	ui *serveUI,
+) error {
 	const tickEvery = 10 * time.Second
 
 	ticker := time.NewTicker(tickEvery)
@@ -221,13 +257,45 @@ func serveLoop(ctx context.Context, poolMgr *pool.Manager, poolNames []model.Poo
 			ui.shutdown()
 			return nil
 		case <-ticker.C:
-			for _, name := range poolNames {
-				if err := poolMgr.Reconcile(ctx, name); err != nil {
-					ui.reconcileError(name, err)
-				}
+			serveReconcilePass(ctx, poolMgr, sandboxFulfiller, poolNames, ui)
+		}
+	}
+}
+
+type servePoolReconciler interface {
+	Reconcile(ctx context.Context, poolName model.PoolName) error
+}
+
+type serveSandboxReconciler interface {
+	Reconcile(ctx context.Context) error
+}
+
+type serveSandboxReconcilerFunc func(ctx context.Context) error
+
+func (f serveSandboxReconcilerFunc) Reconcile(ctx context.Context) error {
+	return f(ctx)
+}
+
+func serveReconcilePass(
+	ctx context.Context,
+	poolMgr servePoolReconciler,
+	sandboxFulfiller serveSandboxReconciler,
+	poolNames []model.PoolName,
+	ui *serveUI,
+) {
+	reconcilePools := func() {
+		for _, name := range poolNames {
+			if err := poolMgr.Reconcile(ctx, name); err != nil {
+				ui.reconcileError(name, err)
 			}
 		}
 	}
+
+	reconcilePools()
+	if err := sandboxFulfiller.Reconcile(ctx); err != nil {
+		ui.printErr(err)
+	}
+	reconcilePools()
 }
 
 // poolSpecToModel converts a config PoolSpec into a runtime model.Pool.

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/Geogboe/boxy/pkg/model"
+)
+
+type fakeServePoolReconciler struct {
+	calls []model.PoolName
+}
+
+func (r *fakeServePoolReconciler) Reconcile(ctx context.Context, poolName model.PoolName) error {
+	_ = ctx
+	r.calls = append(r.calls, poolName)
+	return nil
+}
+
+type fakeServeSandboxReconciler struct {
+	calls int
+}
+
+func (r *fakeServeSandboxReconciler) Reconcile(ctx context.Context) error {
+	_ = ctx
+	r.calls++
+	return nil
+}
+
+func TestServeReconcilePass_ReconcilesPoolsBeforeAndAfterSandboxFulfillment(t *testing.T) {
+	t.Parallel()
+
+	pools := &fakeServePoolReconciler{}
+	sandboxes := &fakeServeSandboxReconciler{}
+
+	serveReconcilePass(context.Background(), pools, sandboxes, []model.PoolName{"web", "win"}, newServeUI(false))
+
+	if sandboxes.calls != 1 {
+		t.Fatalf("sandbox reconcile calls = %d, want 1", sandboxes.calls)
+	}
+
+	want := []model.PoolName{"web", "win", "web", "win"}
+	if len(pools.calls) != len(want) {
+		t.Fatalf("pool reconcile calls = %v, want %v", pools.calls, want)
+	}
+	for i := range want {
+		if pools.calls[i] != want[i] {
+			t.Fatalf("pool reconcile calls = %v, want %v", pools.calls, want)
+		}
+	}
+}
+
+func TestServeReconcilePass_RunsPostFulfillmentPoolReconcileEvenAfterSandboxError(t *testing.T) {
+	t.Parallel()
+
+	pools := &fakeServePoolReconciler{}
+	sandboxes := serveSandboxReconcilerFunc(func(ctx context.Context) error {
+		_ = ctx
+		return fmt.Errorf("boom")
+	})
+
+	serveReconcilePass(context.Background(), pools, sandboxes, []model.PoolName{"web"}, newServeUI(false))
+
+	want := []model.PoolName{"web", "web"}
+	if len(pools.calls) != len(want) {
+		t.Fatalf("pool reconcile calls = %v, want %v", pools.calls, want)
+	}
+	for i := range want {
+		if pools.calls[i] != want[i] {
+			t.Fatalf("pool reconcile calls = %v, want %v", pools.calls, want)
+		}
+	}
+}
+
+func TestOpenServeStore_PersistsStateAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "boxy.yaml")
+
+	first, statePath, err := openServeStore(cfgPath)
+	if err != nil {
+		t.Fatalf("openServeStore(first): %v", err)
+	}
+	if want := filepath.Join(filepath.Dir(cfgPath), ".boxy", "state.json"); statePath != want {
+		t.Fatalf("state path = %q, want %q", statePath, want)
+	}
+
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "persisted",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "web", Count: 1}},
+	}
+	if err := first.CreateSandbox(context.Background(), sb); err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+
+	second, statePath2, err := openServeStore(cfgPath)
+	if err != nil {
+		t.Fatalf("openServeStore(second): %v", err)
+	}
+	if statePath2 != statePath {
+		t.Fatalf("second state path = %q, want %q", statePath2, statePath)
+	}
+
+	got, err := second.GetSandbox(context.Background(), sb.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+	if got.ID != sb.ID || got.Status != model.SandboxStatusPending {
+		t.Fatalf("sandbox = %+v, want pending sandbox %q", got, sb.ID)
+	}
+}

--- a/internal/cli/serve_ui.go
+++ b/internal/cli/serve_ui.go
@@ -34,6 +34,15 @@ func (u *serveUI) reconcileError(pool model.PoolName, err error) {
 	}
 }
 
+// printErr reports a non-pool-specific reconciliation error.
+func (u *serveUI) printErr(err error) {
+	if u.pretty {
+		pterm.Error.Printfln("%v", err)
+	} else {
+		slog.Error("reconcile sandboxes", "err", err)
+	}
+}
+
 // shutdown prints the shutdown message.
 func (u *serveUI) shutdown() {
 	if u.pretty {

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -41,6 +41,19 @@ func (m *Manager) SetClock(c Clock) {
 
 // Reconcile performs one reconciliation pass for the pool.
 func (m *Manager) Reconcile(ctx context.Context, poolName model.PoolName) error {
+	return m.reconcile(ctx, poolName, 0)
+}
+
+// EnsureReady ensures the pool has at least minReady resources available,
+// without mutating the pool's configured preheat policy.
+func (m *Manager) EnsureReady(ctx context.Context, poolName model.PoolName, minReady int) error {
+	if minReady <= 0 {
+		return nil
+	}
+	return m.reconcile(ctx, poolName, minReady)
+}
+
+func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minReadyOverride int) error {
 	if m == nil {
 		return fmt.Errorf("pool manager is nil")
 	}
@@ -83,7 +96,12 @@ func (m *Manager) Reconcile(ctx context.Context, poolName model.PoolName) error 
 			}
 			p.Inventory.Resources = kept
 
-			toProv := computeToProvision(p)
+			effectiveMinReady := p.Policies.Preheat.MinReady
+			if minReadyOverride > effectiveMinReady {
+				effectiveMinReady = minReadyOverride
+			}
+
+			toProv := computeToProvision(p, effectiveMinReady)
 			reason := "noop"
 			should := false
 			if len(stale) > 0 || toProv > 0 {
@@ -165,8 +183,7 @@ func computeStale(p model.Pool, now time.Time) (stale []model.Resource, kept []m
 	return stale, kept, nil
 }
 
-func computeToProvision(p model.Pool) int {
-	minReady := p.Policies.Preheat.MinReady
+func computeToProvision(p model.Pool, minReady int) int {
 	maxTotal := p.Policies.Preheat.MaxTotal
 	if minReady <= 0 {
 		return 0

--- a/internal/sandbox/fulfiller.go
+++ b/internal/sandbox/fulfiller.go
@@ -1,0 +1,301 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+type readyEnsurer interface {
+	EnsureReady(ctx context.Context, poolName model.PoolName, minReady int) error
+}
+
+// Fulfiller reconciles pending sandbox requests into ready sandboxes.
+type Fulfiller struct {
+	store      store.Store
+	pools      readyEnsurer
+	sandboxMgr *Manager
+}
+
+type poolAllocation struct {
+	poolName model.PoolName
+	count    int
+}
+
+type allocationSnapshot struct {
+	sandbox   model.Sandbox
+	pools     map[model.PoolName]model.Pool
+	resources map[model.ResourceID]model.Resource
+}
+
+// NewFulfiller creates a sandbox request fulfiller.
+func NewFulfiller(st store.Store, pools readyEnsurer, sandboxMgr *Manager) *Fulfiller {
+	return &Fulfiller{store: st, pools: pools, sandboxMgr: sandboxMgr}
+}
+
+// Reconcile processes all pending or provisioning sandbox requests.
+func (f *Fulfiller) Reconcile(ctx context.Context) error {
+	if f == nil {
+		return fmt.Errorf("sandbox fulfiller is nil")
+	}
+	if f.store == nil {
+		return fmt.Errorf("store is nil")
+	}
+	if f.pools == nil {
+		return fmt.Errorf("pool manager is nil")
+	}
+	if f.sandboxMgr == nil {
+		return fmt.Errorf("sandbox manager is nil")
+	}
+
+	sandboxes, err := f.store.ListSandboxes(ctx)
+	if err != nil {
+		return fmt.Errorf("list sandboxes: %w", err)
+	}
+
+	sort.Slice(sandboxes, func(i, j int) bool {
+		return sandboxes[i].ID < sandboxes[j].ID
+	})
+
+	for _, sb := range sandboxes {
+		if sb.Status != model.SandboxStatusPending && sb.Status != model.SandboxStatusProvisioning {
+			continue
+		}
+		if err := f.reconcileSandbox(ctx, sb.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (f *Fulfiller) reconcileSandbox(ctx context.Context, id model.SandboxID) error {
+	sb, err := f.store.GetSandbox(ctx, id)
+	if err == store.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get sandbox %q: %w", id, err)
+	}
+
+	if len(sb.Requests) == 0 {
+		return f.failSandbox(ctx, sb, "sandbox requests are required")
+	}
+
+	pools, err := f.store.ListPools(ctx)
+	if err != nil {
+		return fmt.Errorf("list pools: %w", err)
+	}
+
+	allocations, err := buildAllocations(sb.Requests, pools)
+	if err != nil {
+		return f.failSandbox(ctx, sb, err.Error())
+	}
+
+	needsProvisioning := false
+	for _, alloc := range allocations {
+		pl, err := f.store.GetPool(ctx, alloc.poolName)
+		if err != nil {
+			return fmt.Errorf("get pool %q: %w", alloc.poolName, err)
+		}
+		if readyCount(pl) < alloc.count {
+			needsProvisioning = true
+			break
+		}
+	}
+
+	if needsProvisioning && sb.Status != model.SandboxStatusProvisioning {
+		sb.Status = model.SandboxStatusProvisioning
+		sb.Error = ""
+		if err := f.store.PutSandbox(ctx, sb); err != nil {
+			return fmt.Errorf("mark sandbox %q provisioning: %w", sb.ID, err)
+		}
+	}
+
+	for _, alloc := range allocations {
+		if err := f.pools.EnsureReady(ctx, alloc.poolName, alloc.count); err != nil {
+			return f.failSandbox(ctx, sb, fmt.Sprintf("ensure ready for pool %q: %v", alloc.poolName, err))
+		}
+	}
+
+	for _, alloc := range allocations {
+		pl, err := f.store.GetPool(ctx, alloc.poolName)
+		if err != nil {
+			return fmt.Errorf("get pool %q after reconcile: %w", alloc.poolName, err)
+		}
+		if readyCount(pl) < alloc.count {
+			return f.failSandbox(ctx, sb, fmt.Sprintf("pool %q has %d ready resource(s), need %d", alloc.poolName, readyCount(pl), alloc.count))
+		}
+	}
+
+	snapshot, err := f.captureAllocationSnapshot(ctx, sb, allocations)
+	if err != nil {
+		return fmt.Errorf("capture allocation snapshot for sandbox %q: %w", sb.ID, err)
+	}
+
+	for _, alloc := range allocations {
+		if _, err := f.sandboxMgr.AddFromPool(ctx, sb.ID, alloc.poolName, alloc.count); err != nil {
+			return f.rollbackAllocation(ctx, snapshot, fmt.Sprintf("allocate from pool %q: %v", alloc.poolName, err))
+		}
+	}
+
+	final, err := f.store.GetSandbox(ctx, sb.ID)
+	if err == store.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get sandbox %q after allocation: %w", sb.ID, err)
+	}
+	final.Status = model.SandboxStatusReady
+	final.Error = ""
+	if err := f.store.PutSandbox(ctx, final); err != nil {
+		return fmt.Errorf("mark sandbox %q ready: %w", final.ID, err)
+	}
+	return nil
+}
+
+func (f *Fulfiller) captureAllocationSnapshot(
+	ctx context.Context,
+	sb model.Sandbox,
+	allocations []poolAllocation,
+) (allocationSnapshot, error) {
+	snapshot := allocationSnapshot{
+		sandbox:   sb,
+		pools:     make(map[model.PoolName]model.Pool, len(allocations)),
+		resources: make(map[model.ResourceID]model.Resource),
+	}
+
+	for _, alloc := range allocations {
+		pl, err := f.store.GetPool(ctx, alloc.poolName)
+		if err != nil {
+			return allocationSnapshot{}, fmt.Errorf("get pool %q: %w", alloc.poolName, err)
+		}
+		snapshot.pools[alloc.poolName] = pl
+		for _, res := range pl.Inventory.Resources {
+			if _, exists := snapshot.resources[res.ID]; exists {
+				continue
+			}
+			stored, err := f.store.GetResource(ctx, res.ID)
+			if err != nil {
+				return allocationSnapshot{}, fmt.Errorf("get resource %q: %w", res.ID, err)
+			}
+			snapshot.resources[res.ID] = stored
+		}
+	}
+
+	return snapshot, nil
+}
+
+func (f *Fulfiller) rollbackAllocation(ctx context.Context, snapshot allocationSnapshot, msg string) error {
+	resourceIDs := make([]string, 0, len(snapshot.resources))
+	for id := range snapshot.resources {
+		resourceIDs = append(resourceIDs, string(id))
+	}
+	sort.Strings(resourceIDs)
+	for _, id := range resourceIDs {
+		res := snapshot.resources[model.ResourceID(id)]
+		if err := f.store.PutResource(ctx, res); err != nil {
+			return fmt.Errorf("restore resource %q: %w", res.ID, err)
+		}
+	}
+
+	poolNames := make([]string, 0, len(snapshot.pools))
+	for name := range snapshot.pools {
+		poolNames = append(poolNames, string(name))
+	}
+	sort.Strings(poolNames)
+	for _, name := range poolNames {
+		pl := snapshot.pools[model.PoolName(name)]
+		if err := f.store.PutPool(ctx, pl); err != nil {
+			return fmt.Errorf("restore pool %q: %w", pl.Name, err)
+		}
+	}
+
+	failed := snapshot.sandbox
+	failed.Status = model.SandboxStatusFailed
+	failed.Error = msg
+	if err := f.store.PutSandbox(ctx, failed); err != nil {
+		return fmt.Errorf("mark sandbox %q failed after rollback: %w", failed.ID, err)
+	}
+	return nil
+}
+
+func (f *Fulfiller) failSandbox(ctx context.Context, sb model.Sandbox, msg string) error {
+	current, err := f.store.GetSandbox(ctx, sb.ID)
+	if err == store.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get sandbox %q for failure update: %w", sb.ID, err)
+	}
+	current.Status = model.SandboxStatusFailed
+	current.Error = msg
+	if err := f.store.PutSandbox(ctx, current); err != nil {
+		return fmt.Errorf("mark sandbox %q failed: %w", sb.ID, err)
+	}
+	return nil
+}
+
+func buildAllocations(requests []model.ResourceRequest, pools []model.Pool) ([]poolAllocation, error) {
+	indexByPool := make(map[model.PoolName]int)
+	allocations := make([]poolAllocation, 0, len(requests))
+
+	for _, req := range requests {
+		if err := req.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid sandbox request: %v", err)
+		}
+		poolName, matchErr := matchPool(req, pools)
+		if matchErr != nil {
+			return nil, matchErr
+		}
+		if idx, ok := indexByPool[poolName]; ok {
+			allocations[idx].count += req.Count
+			continue
+		}
+		indexByPool[poolName] = len(allocations)
+		allocations = append(allocations, poolAllocation{poolName: poolName, count: req.Count})
+	}
+
+	return allocations, nil
+}
+
+func matchPool(req model.ResourceRequest, pools []model.Pool) (model.PoolName, error) {
+	var matches []model.PoolName
+	for _, pl := range pools {
+		if pl.Inventory.ExpectedType != req.Type {
+			continue
+		}
+		if pl.Inventory.ExpectedProfile != req.Profile {
+			continue
+		}
+		matches = append(matches, pl.Name)
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no pool matches request type=%q profile=%q", req.Type, req.Profile)
+	case 1:
+		return matches[0], nil
+	default:
+		names := make([]string, 0, len(matches))
+		for _, name := range matches {
+			names = append(names, string(name))
+		}
+		sort.Strings(names)
+		return "", fmt.Errorf("multiple pools match request type=%q profile=%q: %s", req.Type, req.Profile, strings.Join(names, ", "))
+	}
+}
+
+func readyCount(p model.Pool) int {
+	count := 0
+	for _, res := range p.Inventory.Resources {
+		if res.State == model.ResourceStateReady {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/sandbox/fulfillment_test.go
+++ b/internal/sandbox/fulfillment_test.go
@@ -1,0 +1,393 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Geogboe/boxy/internal/pool"
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+type fakeAllocator struct{}
+
+func (fakeAllocator) Allocate(ctx context.Context, p model.Pool, r model.Resource) (map[string]any, error) {
+	_ = ctx
+	_ = p
+	return map[string]any{"allocated": true, "resource_id": string(r.ID)}, nil
+}
+
+type failingAllocator struct {
+	failPool model.PoolName
+}
+
+func (a failingAllocator) Allocate(ctx context.Context, p model.Pool, r model.Resource) (map[string]any, error) {
+	_ = ctx
+	_ = r
+	if p.Name == a.failPool {
+		return nil, fmt.Errorf("allocator failed for pool %s", p.Name)
+	}
+	return map[string]any{"allocated": true}, nil
+}
+
+type fakeFulfillProvisioner struct {
+	nextID   int
+	failPool model.PoolName
+}
+
+func (p *fakeFulfillProvisioner) Provision(ctx context.Context, pl model.Pool) (model.Resource, error) {
+	_ = ctx
+	if pl.Name == p.failPool {
+		return model.Resource{}, fmt.Errorf("provision %s: boom", pl.Name)
+	}
+	p.nextID++
+	return model.Resource{
+		ID:        model.ResourceID(fmt.Sprintf("res-%d", p.nextID)),
+		Type:      pl.Inventory.ExpectedType,
+		Profile:   pl.Inventory.ExpectedProfile,
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(int64(1000+p.nextID), 0).UTC(),
+		UpdatedAt: time.Unix(int64(1000+p.nextID), 0).UTC(),
+	}, nil
+}
+
+func (p *fakeFulfillProvisioner) Destroy(ctx context.Context, pool model.Pool, res model.Resource) error {
+	_ = ctx
+	_ = pool
+	_ = res
+	return nil
+}
+
+func TestFulfiller_ReconcilePending_MarksSandboxReady(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	ready := model.Resource{
+		ID:        "res-ready",
+		Type:      model.ResourceTypeContainer,
+		Profile:   "kali",
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(1, 0).UTC(),
+		UpdatedAt: time.Unix(1, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1}},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, pool.New(st, &fakeFulfillProvisioner{}), New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusReady {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusReady)
+	}
+	if got.Error != "" {
+		t.Fatalf("error = %q, want empty", got.Error)
+	}
+	if len(got.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(got.Resources))
+	}
+
+	res, err := st.GetResource(ctx, got.Resources[0])
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	if res.State != model.ResourceStateAllocated {
+		t.Fatalf("resource state = %q, want %q", res.State, model.ResourceStateAllocated)
+	}
+}
+
+func TestFulfiller_ReconcilePending_ProvisionsResourcesBeforeAllocation(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MaxTotal: 2},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1}},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	prov := &fakeFulfillProvisioner{}
+	f := NewFulfiller(st, pool.New(st, prov), New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusReady {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusReady)
+	}
+	if prov.nextID != 1 {
+		t.Fatalf("provision count = %d, want 1", prov.nextID)
+	}
+}
+
+func TestFulfiller_ReconcilePending_MarksSandboxFailedWhenNoMatchingPool(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "missing", Count: 1}},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, pool.New(st, &fakeFulfillProvisioner{}), New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusFailed {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusFailed)
+	}
+	if !strings.Contains(got.Error, "no pool matches request") {
+		t.Fatalf("error = %q, want matching-pool failure", got.Error)
+	}
+	if len(got.Resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(got.Resources))
+	}
+}
+
+func TestFulfiller_ReconcilePending_DoesNotPartiallyAllocateAcrossGroups(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	ready := model.Resource{
+		ID:        "res-ready",
+		Type:      model.ResourceTypeContainer,
+		Profile:   "kali",
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(1, 0).UTC(),
+		UpdatedAt: time.Unix(1, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	sb := model.Sandbox{
+		ID:     "sb-1",
+		Name:   "lab",
+		Status: model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{
+			{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1},
+			{Type: model.ResourceTypeVM, Profile: "missing", Count: 1},
+		},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, pool.New(st, &fakeFulfillProvisioner{}), New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusFailed {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusFailed)
+	}
+	if len(got.Resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(got.Resources))
+	}
+
+	poolAfter, err := st.GetPool(ctx, "kali")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(poolAfter.Inventory.Resources) != 1 {
+		t.Fatalf("pool inventory len = %d, want 1", len(poolAfter.Inventory.Resources))
+	}
+
+	resAfter, err := st.GetResource(ctx, ready.ID)
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	if resAfter.State != model.ResourceStateReady {
+		t.Fatalf("resource state = %q, want %q", resAfter.State, model.ResourceStateReady)
+	}
+}
+
+func TestFulfiller_ReconcilePending_RollsBackEarlierAllocationsWhenLaterGroupFails(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	webRes := model.Resource{
+		ID:        "res-web",
+		Type:      model.ResourceTypeContainer,
+		Profile:   "web",
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(1, 0).UTC(),
+		UpdatedAt: time.Unix(1, 0).UTC(),
+	}
+	winRes := model.Resource{
+		ID:        "res-win",
+		Type:      model.ResourceTypeVM,
+		Profile:   "win",
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(2, 0).UTC(),
+		UpdatedAt: time.Unix(2, 0).UTC(),
+	}
+	for _, res := range []model.Resource{webRes, winRes} {
+		if err := st.PutResource(ctx, res); err != nil {
+			t.Fatalf("put resource %q: %v", res.ID, err)
+		}
+	}
+	for _, pl := range []model.Pool{
+		{
+			Name: "web",
+			Inventory: model.ResourceCollection{
+				ExpectedType:    model.ResourceTypeContainer,
+				ExpectedProfile: "web",
+				Resources:       []model.Resource{webRes},
+			},
+		},
+		{
+			Name: "win",
+			Inventory: model.ResourceCollection{
+				ExpectedType:    model.ResourceTypeVM,
+				ExpectedProfile: "win",
+				Resources:       []model.Resource{winRes},
+			},
+		},
+	} {
+		if err := st.PutPool(ctx, pl); err != nil {
+			t.Fatalf("put pool %q: %v", pl.Name, err)
+		}
+	}
+
+	sb := model.Sandbox{
+		ID:     "sb-1",
+		Name:   "lab",
+		Status: model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{
+			{Type: model.ResourceTypeContainer, Profile: "web", Count: 1},
+			{Type: model.ResourceTypeVM, Profile: "win", Count: 1},
+		},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, pool.New(st, &fakeFulfillProvisioner{}), New(st, failingAllocator{failPool: "win"}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusFailed {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusFailed)
+	}
+	if len(got.Resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(got.Resources))
+	}
+	if !strings.Contains(got.Error, "allocator failed for pool win") {
+		t.Fatalf("error = %q, want allocator failure", got.Error)
+	}
+
+	for _, poolName := range []model.PoolName{"web", "win"} {
+		pl, err := st.GetPool(ctx, poolName)
+		if err != nil {
+			t.Fatalf("get pool %q: %v", poolName, err)
+		}
+		if len(pl.Inventory.Resources) != 1 {
+			t.Fatalf("pool %q inventory len = %d, want 1", poolName, len(pl.Inventory.Resources))
+		}
+		if pl.Inventory.Resources[0].State != model.ResourceStateReady {
+			t.Fatalf("pool %q resource state = %q, want %q", poolName, pl.Inventory.Resources[0].State, model.ResourceStateReady)
+		}
+	}
+
+	for _, resID := range []model.ResourceID{webRes.ID, winRes.ID} {
+		res, err := st.GetResource(ctx, resID)
+		if err != nil {
+			t.Fatalf("get resource %q: %v", resID, err)
+		}
+		if res.State != model.ResourceStateReady {
+			t.Fatalf("resource %q state = %q, want %q", resID, res.State, model.ResourceStateReady)
+		}
+	}
+}

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -23,8 +23,18 @@ func New(s store.Store, allocator SandboxAllocator) *Manager {
 	return &Manager{store: s, allocator: allocator}
 }
 
-// Create creates an empty sandbox.
+// Create creates an empty sandbox request.
 func (m *Manager) Create(ctx context.Context, sbName string, policies model.SandboxPolicies) (model.Sandbox, error) {
+	return m.CreateRequested(ctx, sbName, policies, nil)
+}
+
+// CreateRequested creates a sandbox request in pending state.
+func (m *Manager) CreateRequested(
+	ctx context.Context,
+	sbName string,
+	policies model.SandboxPolicies,
+	requests []model.ResourceRequest,
+) (model.Sandbox, error) {
 	if m == nil {
 		return model.Sandbox{}, fmt.Errorf("sandbox manager is nil")
 	}
@@ -39,6 +49,8 @@ func (m *Manager) Create(ctx context.Context, sbName string, policies model.Sand
 		ID:       sbID,
 		Name:     sbName,
 		Policies: policies,
+		Status:   model.SandboxStatusPending,
+		Requests: append([]model.ResourceRequest(nil), requests...),
 	}
 	if err := m.store.CreateSandbox(ctx, sb); err != nil {
 		return model.Sandbox{}, fmt.Errorf("create sandbox: %w", err)
@@ -97,10 +109,6 @@ func (m *Manager) AddFromPool(
 	}
 
 	sb.Resources = append(sb.Resources, resourceIDs(selected)...)
-	if err := m.store.PutSandbox(ctx, sb); err != nil {
-		return model.Sandbox{}, fmt.Errorf("put sandbox: %w", err)
-	}
-
 	for _, res := range selected {
 		if res.ID == "" {
 			return model.Sandbox{}, fmt.Errorf("selected resource has empty id")
@@ -123,6 +131,10 @@ func (m *Manager) AddFromPool(
 		if err := m.store.PutResource(ctx, res); err != nil {
 			return model.Sandbox{}, fmt.Errorf("put resource %q: %w", res.ID, err)
 		}
+	}
+
+	if err := m.store.PutSandbox(ctx, sb); err != nil {
+		return model.Sandbox{}, fmt.Errorf("put sandbox: %w", err)
 	}
 
 	return sb, nil
@@ -191,6 +203,7 @@ func (m *Manager) CreateFromPool(
 		ID:        sbID,
 		Name:      sbName,
 		Policies:  policies,
+		Status:    model.SandboxStatusReady,
 		Resources: resourceIDs(selected),
 	}
 	if err := m.store.CreateSandbox(ctx, sb); err != nil {

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -72,3 +72,60 @@ func TestManager_CreateFromPool_ConsumesReadyResource(t *testing.T) {
 		t.Fatalf("expected resource allocated, got %q", updatedRes.State)
 	}
 }
+
+func TestManager_AddFromPool_PreservesSandboxStatusUntilCallerFinalizes(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	ready := model.Resource{
+		ID:        "res_1",
+		Type:      model.ResourceTypeContainer,
+		Profile:   model.ResourceProfileDefault,
+		Provider:  model.ProviderRef{Name: "prov_1"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(1, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+
+	pool := model.Pool{
+		Name:      "docker-containers",
+		Policies:  model.PoolPolicies{Preheat: model.PreheatPolicy{MinReady: 0}},
+		Inventory: model.ResourceCollection{ExpectedType: model.ResourceTypeContainer, ExpectedProfile: model.ResourceProfileDefault, Resources: []model.Resource{ready}},
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "demo",
+		Status:   model.SandboxStatusProvisioning,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: model.ResourceProfileDefault, Count: 1}},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	mgr := New(st, nil)
+	got, err := mgr.AddFromPool(ctx, sb.ID, pool.Name, 1)
+	if err != nil {
+		t.Fatalf("add from pool: %v", err)
+	}
+
+	if got.Status != model.SandboxStatusProvisioning {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusProvisioning)
+	}
+
+	stored, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if stored.Status != model.SandboxStatusProvisioning {
+		t.Fatalf("stored status = %q, want %q", stored.Status, model.SandboxStatusProvisioning)
+	}
+	if len(stored.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(stored.Resources))
+	}
+}

--- a/internal/server/api_sandboxes.go
+++ b/internal/server/api_sandboxes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/Geogboe/boxy/pkg/httpjson"
 	"github.com/Geogboe/boxy/pkg/model"
@@ -37,23 +38,39 @@ func (s *Server) handleGetSandbox(w http.ResponseWriter, r *http.Request) {
 
 // createSandboxRequest is the request body for POST /api/v1/sandboxes.
 type createSandboxRequest struct {
-	Name     string                `json:"name"`
-	Policies model.SandboxPolicies `json:"policies,omitempty"`
+	Name     string                  `json:"name"`
+	Policies model.SandboxPolicies   `json:"policies,omitempty"`
+	Requests []model.ResourceRequest `json:"requests"`
 }
 
-// handleCreateSandbox creates a new sandbox and returns it with 201.
+// handleCreateSandbox creates a new sandbox request and returns it with 202.
 func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	var req createSandboxRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		httpjson.Error(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	sb, err := s.sandboxMgr.Create(r.Context(), req.Name, req.Policies)
+	if strings.TrimSpace(req.Name) == "" {
+		httpjson.Error(w, http.StatusBadRequest, "sandbox name is required")
+		return
+	}
+	if len(req.Requests) == 0 {
+		httpjson.Error(w, http.StatusBadRequest, "sandbox requests are required")
+		return
+	}
+	for _, request := range req.Requests {
+		if err := request.Validate(); err != nil {
+			httpjson.Error(w, http.StatusBadRequest, "invalid sandbox request: "+err.Error())
+			return
+		}
+	}
+
+	sb, err := s.sandboxMgr.CreateRequested(r.Context(), req.Name, req.Policies, req.Requests)
 	if err != nil {
 		httpjson.Error(w, http.StatusInternalServerError, "failed to create sandbox")
 		return
 	}
-	httpjson.Write(w, http.StatusCreated, sb)
+	httpjson.Write(w, http.StatusAccepted, sb)
 }
 
 // handleDeleteSandbox deletes a sandbox by ID and returns 204.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -106,7 +106,12 @@ func TestAPI_ListSandboxes_withData(t *testing.T) {
 	t.Parallel()
 	st := store.NewMemoryStore()
 	ctx := context.Background()
-	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-1", Name: "test"})
+	_ = st.CreateSandbox(ctx, model.Sandbox{
+		ID:       "sb-1",
+		Name:     "test",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "alpine", Count: 1}},
+	})
 
 	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
 	w := httptest.NewRecorder()
@@ -122,6 +127,9 @@ func TestAPI_ListSandboxes_withData(t *testing.T) {
 	}
 	if sbs[0].ID != "sb-1" {
 		t.Fatalf("sandbox id = %q, want %q", sbs[0].ID, "sb-1")
+	}
+	if sbs[0].Status != model.SandboxStatusPending {
+		t.Fatalf("sandbox status = %q, want %q", sbs[0].Status, model.SandboxStatusPending)
 	}
 }
 
@@ -246,7 +254,13 @@ func TestAPI_GetSandbox_found(t *testing.T) {
 	t.Parallel()
 	st := store.NewMemoryStore()
 	ctx := context.Background()
-	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-42", Name: "found"})
+	_ = st.CreateSandbox(ctx, model.Sandbox{
+		ID:       "sb-42",
+		Name:     "found",
+		Status:   model.SandboxStatusFailed,
+		Error:    "pool not found",
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "demo", Count: 1}},
+	})
 
 	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
 	w := httptest.NewRecorder()
@@ -262,6 +276,12 @@ func TestAPI_GetSandbox_found(t *testing.T) {
 	}
 	if sb.ID != "sb-42" {
 		t.Fatalf("sandbox id = %q, want %q", sb.ID, "sb-42")
+	}
+	if sb.Status != model.SandboxStatusFailed {
+		t.Fatalf("sandbox status = %q, want %q", sb.Status, model.SandboxStatusFailed)
+	}
+	if sb.Error != "pool not found" {
+		t.Fatalf("sandbox error = %q, want %q", sb.Error, "pool not found")
 	}
 }
 
@@ -282,14 +302,14 @@ func TestAPI_CreateSandbox(t *testing.T) {
 	st := store.NewMemoryStore()
 	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
 
-	body := bytes.NewBufferString(`{"name":"new-box"}`)
+	body := bytes.NewBufferString(`{"name":"new-box","requests":[{"type":"container","profile":"alpine","count":2}]}`)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes", body)
 	r.Header.Set("Content-Type", "application/json")
 	mux.ServeHTTP(w, r)
 
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body: %s", w.Code, w.Body.String())
 	}
 	var sb model.Sandbox
 	if err := json.Unmarshal(w.Body.Bytes(), &sb); err != nil {
@@ -300,6 +320,50 @@ func TestAPI_CreateSandbox(t *testing.T) {
 	}
 	if sb.Name != "new-box" {
 		t.Fatalf("sandbox name = %q, want %q", sb.Name, "new-box")
+	}
+	if sb.Status != model.SandboxStatusPending {
+		t.Fatalf("sandbox status = %q, want %q", sb.Status, model.SandboxStatusPending)
+	}
+	if len(sb.Resources) != 0 {
+		t.Fatalf("sandbox resources len = %d, want 0", len(sb.Resources))
+	}
+	if len(sb.Requests) != 1 {
+		t.Fatalf("sandbox requests len = %d, want 1", len(sb.Requests))
+	}
+	if sb.Requests[0].Type != model.ResourceTypeContainer || sb.Requests[0].Profile != "alpine" || sb.Requests[0].Count != 2 {
+		t.Fatalf("sandbox request = %+v", sb.Requests[0])
+	}
+}
+
+func TestAPI_CreateSandbox_requiresRequests(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+
+	body := bytes.NewBufferString(`{"name":"new-box"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes", body)
+	r.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_CreateSandbox_validatesRequests(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+
+	body := bytes.NewBufferString(`{"name":"new-box","requests":[{"type":"container","profile":"","count":0}]}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes", body)
+	r.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/server/templates/sandboxes.html
+++ b/internal/server/templates/sandboxes.html
@@ -19,6 +19,7 @@
     <tr>
       <th>ID</th>
       <th>Name</th>
+      <th>Status</th>
       <th>Resources</th>
     </tr>
   </thead>
@@ -27,6 +28,7 @@
     <tr>
       <td><code>{{.ID}}</code></td>
       <td>{{.Name}}</td>
+      <td>{{.Status}}</td>
       <td>{{len .Resources}}</td>
     </tr>
     {{end}}

--- a/pkg/model/sandbox.go
+++ b/pkg/model/sandbox.go
@@ -3,6 +3,16 @@ package model
 // SandboxID is a stable identifier for a sandbox (user-facing handle).
 type SandboxID string
 
+// SandboxStatus is the lifecycle state of a sandbox request.
+type SandboxStatus string
+
+const (
+	SandboxStatusPending      SandboxStatus = "pending"
+	SandboxStatusProvisioning SandboxStatus = "provisioning"
+	SandboxStatusReady        SandboxStatus = "ready"
+	SandboxStatusFailed       SandboxStatus = "failed"
+)
+
 // Sandbox is a user-facing environment that contains 1..N resources.
 //
 // This model is intentionally minimal. Orchestration state and richer composition
@@ -13,6 +23,15 @@ type Sandbox struct {
 
 	// Policies are sandbox-level behavioral controls (security, retention, etc).
 	Policies SandboxPolicies `json:"policies,omitempty" yaml:"policies,omitempty"`
+
+	// Status is the async lifecycle state of the sandbox request.
+	Status SandboxStatus `json:"status,omitempty" yaml:"status,omitempty"`
+
+	// Requests are the desired resources for this sandbox.
+	Requests []ResourceRequest `json:"requests,omitempty" yaml:"requests,omitempty"`
+
+	// Error is a human-readable failure detail when Status=failed.
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
 
 	// Resources are the resources that make up this sandbox.
 	Resources []ResourceID `json:"resources,omitempty" yaml:"resources,omitempty"`

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -162,6 +162,53 @@ func testStoreDeleteSandbox(t *testing.T, newStore storeFactory) {
 	})
 }
 
+func testStoreSandboxFieldsRoundTrip(t *testing.T, newStore storeFactory) {
+	t.Helper()
+
+	t.Run("Sandbox_fields_round_trip", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		s := newStore(t)
+
+		want := model.Sandbox{
+			ID:     "sb-async",
+			Name:   "async-lab",
+			Status: model.SandboxStatusProvisioning,
+			Error:  "still provisioning",
+			Policies: model.SandboxPolicies{
+				AutoDestroyAfter: "8h",
+				SecurityProfile:  "lab",
+			},
+			Requests: []model.ResourceRequest{
+				{Type: model.ResourceTypeContainer, Profile: "alpine", Count: 2},
+			},
+			Resources: []model.ResourceID{"res-1"},
+		}
+
+		if err := s.CreateSandbox(ctx, want); err != nil {
+			t.Fatalf("CreateSandbox: %v", err)
+		}
+
+		got, err := s.GetSandbox(ctx, want.ID)
+		if err != nil {
+			t.Fatalf("GetSandbox: %v", err)
+		}
+
+		if got.Status != want.Status {
+			t.Fatalf("status = %q, want %q", got.Status, want.Status)
+		}
+		if got.Error != want.Error {
+			t.Fatalf("error = %q, want %q", got.Error, want.Error)
+		}
+		if len(got.Requests) != 1 {
+			t.Fatalf("requests len = %d, want 1", len(got.Requests))
+		}
+		if got.Requests[0] != want.Requests[0] {
+			t.Fatalf("request = %+v, want %+v", got.Requests[0], want.Requests[0])
+		}
+	})
+}
+
 var memoryFactory = func(t *testing.T) store.Store {
 	return store.NewMemoryStore()
 }
@@ -193,4 +240,14 @@ func TestMemoryStore_DeleteSandbox(t *testing.T) {
 func TestDiskStore_DeleteSandbox(t *testing.T) {
 	t.Parallel()
 	testStoreDeleteSandbox(t, diskFactory)
+}
+
+func TestMemoryStore_SandboxFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	testStoreSandboxFieldsRoundTrip(t, memoryFactory)
+}
+
+func TestDiskStore_SandboxFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	testStoreSandboxFieldsRoundTrip(t, diskFactory)
 }

--- a/tests/e2e/serve-api.hurl
+++ b/tests/e2e/serve-api.hurl
@@ -41,15 +41,16 @@ jsonpath "$" count == 0
 
 POST {{base_url}}/api/v1/sandboxes
 Content-Type: application/json
-{"name": "hurl-test"}
+{"name": "hurl-test", "requests": [{"type": "container", "profile": "demo", "count": 1}]}
 
-HTTP 201
+HTTP 202
 [Captures]
 sandbox_id: jsonpath "$.id"
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.name" == "hurl-test"
 jsonpath "$.id" isString
+jsonpath "$.status" == "pending"
 
 
 # ── GET /api/v1/sandboxes/{id} ──────────────────────────────────────────
@@ -58,6 +59,7 @@ GET {{base_url}}/api/v1/sandboxes/{{sandbox_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == {{sandbox_id}}
+jsonpath "$.status" exists
 
 
 # ── DELETE /api/v1/sandboxes/{id} ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- add async sandbox lifecycle fields and request-based sandbox API behavior
- fulfill pending sandbox requests on the daemon with rollback-safe allocation and same-tick pool replenishment
- persist daemon runtime state to disk so accepted sandbox requests survive restart

## Validation
- task fmt
- task test
- task lint
- task build
- live validation of async create/get/list/delete against devfactory-backed serve
- live validation that an accepted async sandbox request survives daemon restart

## Notes
- this closes the async API work for #66
- the disconnected local `boxy sandbox create -f ...` flow remains follow-on work for #67