### PR TITLE
feat(cli): rewrite sandbox create with async api flow

### DIFF
--- a/.archive/cli/legacy-sandbox-create.md
+++ b/.archive/cli/legacy-sandbox-create.md
@@ -1,0 +1,37 @@
+# Legacy Sandbox Create Flow
+
+Archived during `#67 Rewrite sandbox create CLI with async API flow`.
+
+## What the legacy path did
+
+Before `#67`, `boxy sandbox create -f ...` performed sandbox creation locally in
+the CLI process instead of delegating to the daemon:
+
+1. Loaded the sandbox spec YAML.
+2. Resolved a local `boxy.yaml`.
+3. Opened a local DiskStore state file.
+4. Registered providers and built drivers.
+5. Started an embedded agent in the CLI.
+6. Upserted pools into local state.
+7. Mutated pool preheat policy to satisfy the request.
+8. Reconciled pools locally to provision resources.
+9. Allocated resources into a locally-created sandbox.
+10. Reconciled pools again to replenish preheat targets.
+
+## Why it was retired
+
+- It bypassed the daemon entirely.
+- It produced sandboxes that were not visible to `boxy serve`.
+- It duplicated orchestration logic that now belongs to the daemon.
+- It blocked the API-first migration tracked by `#33` / `#67`.
+
+## What replaced it
+
+The live create path is now:
+
+1. Load sandbox spec YAML.
+2. Query daemon pools.
+3. Compile spec pools into async API `requests`.
+4. `POST /api/v1/sandboxes`.
+5. Poll until `ready` or `failed` unless `--no-wait` is used.
+6. Fetch resources from the daemon and show connection info.

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,11 @@ bin/
 
 .env
 .envrc
-.archive/
+.archive/*
+!.archive/ROADMAP.md
+!.archive/cli/
+.archive/cli/*
+!.archive/cli/legacy-sandbox-create.md
 
 # Logs
 logs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ docs/adr/             # Architecture Decision Records
 - A sandbox is an environment that can be as small as a single resource or as large as a full lab.
 - Sandbox creation via the REST API is asynchronous: `POST /api/v1/sandboxes` persists a sandbox request in `pending`, the daemon fulfillment loop provisions/allocates resources, and the sandbox transitions to `ready` or `failed`.
 - `boxy serve` persists runtime state in `.boxy/state.json` next to the active config (or under the working directory when no config file is used), so accepted async sandbox requests survive normal daemon restarts.
+- `boxy sandbox create -f ...` is daemon-backed: the CLI loads a sandbox spec, resolves named pools from the daemon pool catalog, submits async `requests`, and waits for `ready`/`failed` by default. Use `--no-wait` to return after the daemon accepts the request.
 - Preferred phrasing when describing compositions:
   - "container sandbox" (1 container)
   - "3 VM lab sandbox" (multi-VM lab)
@@ -99,6 +100,7 @@ When decisions are made, save them as ADR documents in /docs/adr. This is a livi
 - Cost model differs from human dev cycles: refactors are cheap when an agent can apply wide changes quickly, resolve merges/rebases, and keep `go test ./...` green.
 - Bias toward a single source of truth: remove duplication promptly and update all call sites together (avoid parallel “old vs new” models).
 - Treat “no regressions” as “no regressions covered by tests”: add/extend targeted tests whenever behavior changes.
+- Use `pkg/` for generic contracts, primitives, or shared vocabulary that reduce conceptual load in isolation. Keep Boxy application workflow glue in `internal/`; do not promote daemon/CLI orchestration code to `pkg/` unless a genuinely general concept has emerged.
 
 ## Development Notes
 

--- a/README.md
+++ b/README.md
@@ -245,14 +245,12 @@ Sandboxes are instantiated via CLI:
 ```
 # From a file (primary path)
 boxy sandbox create -f pentest-lab.sandbox.yaml
-boxy sandbox create -f pentest-lab.sandbox.yaml -n 10  # 10 instances for a class
 
-# Quick one-off (sugar)
-boxy sandbox create --pool kali
-boxy sandbox create --pool kali:3 --pool ubuntu-targets:1
+# Return after the daemon accepts the request instead of waiting for ready/failed
+boxy sandbox create -f pentest-lab.sandbox.yaml --no-wait
 ```
 
-The file-based path is the primary, repeatable, version-controlled way. The `--pool` shorthand is sugar for quick testing — it constructs the same sandbox object internally.
+The file-based path is the primary, repeatable, version-controlled way. The CLI compiles pool references from the spec into daemon API requests, submits them to `boxy serve`, and waits for a terminal sandbox status by default.
 
 See [examples/](examples/) for complete configurations.
 
@@ -273,7 +271,7 @@ boxy init                               — create starter boxy.yaml in current 
 boxy serve                              — start the daemon (API server + reconcile loop)
 boxy status                             — check server health and summary
 boxy config validate                    — validate config file and exit
-boxy sandbox create -f <file>           — create sandbox from a spec file
+boxy sandbox create -f <file>           — create sandbox from a spec file (waits by default; use --no-wait to return after acceptance)
 boxy sandbox list                       — list sandboxes
 boxy sandbox get <id>                   — get sandbox details
 boxy sandbox delete <id>                — delete a sandbox

--- a/docs/cli-wireframe.md
+++ b/docs/cli-wireframe.md
@@ -67,10 +67,17 @@ boxy
 │   ├── --server <addr>                          Server address (default 127.0.0.1:9090)
 │   │
 │   ├── create -f <spec>                         Create sandbox from spec file
-│   │   └── -f, --file <path>                      Sandbox spec file (required)
+│   │   ├── -f, --file <path>                      Sandbox spec file (required)
+│   │   └── --no-wait                              Return after request is accepted
 │   │
 │   │   $ boxy sandbox create -f lab.sandbox.yaml
-│   │     Sandbox created  id=sb-a1b2c3  name=pentest-lab  resources=3
+│   │     Waiting for sandbox "pentest-lab"  sb-a1b2c3 · 3 resource(s)
+│   │
+│   │   $ boxy sandbox create -f lab.sandbox.yaml --no-wait
+│   │     Sandbox accepted
+│   │       id: sb-a1b2c3
+│   │       name: pentest-lab
+│   │       status: pending
 │   │
 │   ├── list                                     List all sandboxes
 │   │

--- a/internal/cli/api_client.go
+++ b/internal/cli/api_client.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -12,9 +14,13 @@ import (
 type apiError struct {
 	StatusCode int
 	URL        string
+	Message    string
 }
 
 func (e *apiError) Error() string {
+	if strings.TrimSpace(e.Message) != "" {
+		return fmt.Sprintf("request to %s returned HTTP %d: %s", e.URL, e.StatusCode, e.Message)
+	}
 	return fmt.Sprintf("request to %s returned HTTP %d", e.URL, e.StatusCode)
 }
 
@@ -26,19 +32,42 @@ func fetchJSON[T any](ctx context.Context, client *http.Client, url string) (T, 
 		return zero, err
 	}
 
-	resp, err := client.Do(req)
+	return doJSON[T](client, req)
+}
+
+func postJSON[TReq any, TResp any](ctx context.Context, client *http.Client, url string, body TReq) (TResp, error) {
+	var zero TResp
+
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return zero, fmt.Errorf("encode request for %s: %w", url, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, buf)
+	if err != nil {
+		return zero, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return doJSON[TResp](client, req)
+}
+
+func doJSON[T any](client *http.Client, req *http.Request) (T, error) {
+	var zero T
+
+	resp, err := client.Do(req) //nolint:gosec // CLI requests intentionally target the user-configured Boxy server.
 	if err != nil {
 		return zero, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return zero, &apiError{StatusCode: resp.StatusCode, URL: url}
+		return zero, decodeAPIError(resp, req.URL.String())
 	}
 
 	var v T
 	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return zero, fmt.Errorf("decode response from %s: %w", url, err)
+		return zero, fmt.Errorf("decode response from %s: %w", req.URL.String(), err)
 	}
 
 	return v, nil
@@ -57,6 +86,25 @@ func deleteAPI(ctx context.Context, client *http.Client, url string) (int, error
 	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode, nil
+}
+
+func decodeAPIError(resp *http.Response, url string) error {
+	body, _ := io.ReadAll(resp.Body)
+	apiErr := &apiError{StatusCode: resp.StatusCode, URL: url}
+	if len(body) == 0 {
+		return apiErr
+	}
+
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Error) != "" {
+		apiErr.Message = payload.Error
+		return apiErr
+	}
+
+	apiErr.Message = strings.TrimSpace(string(body))
+	return apiErr
 }
 
 func apiBaseURL(server string) string {

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -10,14 +10,14 @@ import (
 )
 
 type sandboxCreateOpts struct {
-	file       string
-	configPath string
-	statePath  string
-	noEnvFile  bool
+	file      string
+	server    string
+	noEnvFile bool
+	noWait    bool
 }
 
 func newSandboxCommand() *cobra.Command {
-	var configPath, statePath, file, server string
+	var file, server string
 
 	cmd := &cobra.Command{
 		Use:   "sandbox",
@@ -30,20 +30,21 @@ func newSandboxCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&server, "server", "", "server address (default 127.0.0.1:9090)")
 	cmd.PersistentFlags().StringVarP(&file, "file", "f", "", "sandbox spec file (default: sandbox.yaml in cwd)")
 
-	var noEnvFile bool
+	var noEnvFile, noWait bool
 	create := &cobra.Command{
 		Use:   "create",
 		Short: "Create a sandbox from a spec file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSandboxCreate(cmd.Context(), sandboxCreateOpts{
-				file:       file,
-				configPath: configPath,
-				statePath:  statePath,
-				noEnvFile:  noEnvFile,
+				file:      file,
+				server:    server,
+				noEnvFile: noEnvFile,
+				noWait:    noWait,
 			})
 		},
 	}
 	create.Flags().BoolVar(&noEnvFile, "no-env-file", false, "skip writing connection info to a .sandbox-<name>.env file")
+	create.Flags().BoolVar(&noWait, "no-wait", false, "return immediately after the sandbox request is accepted")
 	cmd.AddCommand(create)
 
 	serverAddr := func() string { return server }
@@ -63,7 +64,6 @@ func runSandboxCreate(ctx context.Context, opts sandboxCreateOpts) error {
 		return fmt.Errorf("no sandbox spec found: pass -f or create sandbox.yaml in cwd")
 	}
 	opts.file = resolveRelative(opts.file)
-	opts.configPath = resolveRelative(opts.configPath)
 	return sandboxCreate(ctx, opts)
 }
 

--- a/internal/cli/sandbox_create.go
+++ b/internal/cli/sandbox_create.go
@@ -2,9 +2,9 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io"
-	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,192 +12,70 @@ import (
 	"time"
 
 	boxyconfig "github.com/Geogboe/boxy/internal/config"
-	"github.com/Geogboe/boxy/internal/pool"
-	"github.com/Geogboe/boxy/internal/sandbox"
-	"github.com/Geogboe/boxy/pkg/agentsdk"
 	"github.com/Geogboe/boxy/pkg/model"
-	"github.com/Geogboe/boxy/pkg/providersdk"
-	"github.com/Geogboe/boxy/pkg/providersdk/builtins"
-	"github.com/Geogboe/boxy/pkg/store"
 	"github.com/pterm/pterm"
 	"golang.org/x/term"
 )
 
-func sandboxCreate(ctx context.Context, opts sandboxCreateOpts) error {
-	// Silence internal slog output; progress is reported via pterm spinners.
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+const sandboxPollInterval = time.Second
 
+type createSandboxBody struct {
+	Name     string                  `json:"name"`
+	Policies model.SandboxPolicies   `json:"policies,omitempty"`
+	Requests []model.ResourceRequest `json:"requests"`
+}
+
+func sandboxCreate(ctx context.Context, opts sandboxCreateOpts) error {
 	pterm.Println()
 
-	// --- Load sandbox spec ---
 	doneSpec := step("Loading sandbox spec")
-	spec, err := boxyconfig.LoadSandboxFile(opts.file)
+	spec, err := loadSandboxSpec(opts.file)
 	if err != nil {
 		return err
-	}
-	if strings.TrimSpace(spec.Name) == "" {
-		return fmt.Errorf("sandbox spec name is required")
-	}
-	if len(spec.Resources) == 0 {
-		return fmt.Errorf("sandbox spec resources is required")
 	}
 	doneSpec(fmt.Sprintf("%s  (%d resource group(s))", spec.Name, len(spec.Resources)))
 
-	// --- Load config ---
-	doneConfig := step("Loading config")
-	cfgPath, err := resolveConfigPath(opts.configPath, opts.file)
+	client := defaultAPIClient()
+	base := apiBaseURL(opts.server)
+
+	donePools := step("Loading pool catalog")
+	pools, err := fetchJSON[[]model.Pool](ctx, client, base+"/api/v1/pools")
+	if err != nil {
+		return fmt.Errorf("load pool catalog: %w", err)
+	}
+	donePools(fmt.Sprintf("%d pool(s)", len(pools)))
+
+	requests, err := compileSandboxRequests(spec, pools)
 	if err != nil {
 		return err
 	}
-	if cfgPath == "" {
-		return fmt.Errorf("no config file found (expected boxy.yaml next to %q or in cwd)", opts.file)
-	}
-	cfg, err := boxyconfig.LoadFile(cfgPath)
+
+	doneCreate := step(fmt.Sprintf("Creating sandbox %q", spec.Name))
+	sb, err := postJSON[createSandboxBody, model.Sandbox](ctx, client, base+"/api/v1/sandboxes", createSandboxBody{
+		Name:     spec.Name,
+		Policies: model.SandboxPolicies{},
+		Requests: requests,
+	})
 	if err != nil {
+		return fmt.Errorf("create sandbox %q: %w", spec.Name, err)
+	}
+	doneCreate(fmt.Sprintf("%s  ·  %s", sb.ID, sb.Status))
+
+	if opts.noWait {
+		printAcceptedSandbox(sb)
+		printSandboxCommands(sb.ID)
+		return nil
+	}
+
+	sb, err = waitForSandboxReady(ctx, client, base, sb)
+	if err != nil {
+		printSandboxCommands(sb.ID)
 		return err
 	}
-	doneConfig(fmt.Sprintf("%s  (%d provider(s), %d pool(s))", filepath.Base(cfgPath), len(cfg.Providers), len(cfg.Pools)))
 
-	// --- Register + validate providers ---
-	doneProviders := step("Registering providers")
-	reg := providersdk.NewRegistry()
-	if err := builtins.RegisterBuiltins(reg); err != nil {
-		return fmt.Errorf("register builtin providers: %w", err)
-	}
-	providers := ensureImplicitProviders(cfg.Providers, cfg.Pools)
-	if err := reg.ValidateInstances(ctx, providers); err != nil {
-		return fmt.Errorf("validate providers: %w", err)
-	}
-	doneProviders(strings.Join(providerTypes(reg), ", "))
-
-	// --- Open state store ---
-	doneState := step("Opening state")
-	statePath := opts.statePath
-	if statePath == "" {
-		statePath = filepath.Join(filepath.Dir(cfgPath), ".boxy", "state.json")
-	}
-	st, err := store.NewDiskStore(statePath)
+	resources, err := hydrateSandboxResources(ctx, client, base, sb)
 	if err != nil {
 		return err
-	}
-	doneState(statePath)
-
-	specByName := make(map[model.PoolName]boxyconfig.PoolSpec, len(cfg.Pools))
-	for i := range cfg.Pools {
-		p := cfg.Pools[i]
-		if strings.TrimSpace(p.Name) == "" {
-			return fmt.Errorf("pools[%d].name is required", i)
-		}
-		specByName[model.PoolName(p.Name)] = p
-	}
-	providerByName := make(map[string]providersdk.Instance, len(providers))
-	for _, inst := range providers {
-		providerByName[inst.Name] = inst
-	}
-
-	for _, ps := range cfg.Pools {
-		mp, err := poolModelFromSpec(ps)
-		if err != nil {
-			return err
-		}
-		if err := upsertPool(ctx, st, mp); err != nil {
-			return err
-		}
-	}
-
-	needByPool := make(map[model.PoolName]int)
-	for i := range spec.Resources {
-		r := spec.Resources[i]
-		if strings.TrimSpace(r.Pool) == "" {
-			return fmt.Errorf("resources[%d].pool is required", i)
-		}
-		if r.Count <= 0 {
-			return fmt.Errorf("resources[%d].count must be > 0", i)
-		}
-		needByPool[model.PoolName(r.Pool)] += r.Count
-	}
-
-	pterm.Println()
-	pterm.Bold.Printfln("  Creating sandbox %q", spec.Name)
-	pterm.Println()
-
-	drivers, err := buildDrivers(reg, providers)
-	if err != nil {
-		return fmt.Errorf("build drivers: %w", err)
-	}
-	embeddedAgent, err := agentsdk.NewEmbeddedAgent("embedded", "Embedded Agent", drivers...)
-	if err != nil {
-		return fmt.Errorf("create embedded agent: %w", err)
-	}
-
-	prov := &pool.AgentProvisioner{
-		Agent:     embeddedAgent,
-		Specs:     specByName,
-		Providers: providerByName,
-	}
-	pm := pool.New(st, prov)
-	sm := sandbox.New(st, prov)
-
-	// --- Ensure pools have enough ready resources ---
-	for poolName, need := range needByPool {
-		p, err := st.GetPool(ctx, poolName)
-		if err != nil {
-			return fmt.Errorf("get pool %q: %w", poolName, err)
-		}
-		if p.Policies.Preheat.MinReady < need {
-			p.Policies.Preheat.MinReady = need
-			if err := st.PutPool(ctx, p); err != nil {
-				return fmt.Errorf("put pool %q: %w", poolName, err)
-			}
-		}
-		label := fmt.Sprintf("Pool %s  provisioning %d resource(s)", poolName, need)
-		spin, _ := boxySpinner.Start(label)
-		t0 := time.Now()
-		if err := pm.Reconcile(ctx, poolName); err != nil {
-			spin.Fail(err.Error())
-			return fmt.Errorf("reconcile pool %q: %w", poolName, err)
-		}
-		spin.Success(label + "  " + pterm.FgDarkGray.Sprintf("done  (%s)", time.Since(t0).Round(time.Millisecond)))
-	}
-
-	// --- Allocate resources into sandbox ---
-	doneAllocate := step(fmt.Sprintf("Allocating sandbox %q", spec.Name))
-	sb, err := sm.Create(ctx, spec.Name, model.SandboxPolicies{})
-	if err != nil {
-		return err
-	}
-	for _, req := range spec.Resources {
-		sb, err = sm.AddFromPool(ctx, sb.ID, model.PoolName(req.Pool), req.Count)
-		if err != nil {
-			return failLocalSandboxCreate(ctx, st, sb.ID, err)
-		}
-	}
-	sb.Status = model.SandboxStatusReady
-	sb.Error = ""
-	if err := st.PutSandbox(ctx, sb); err != nil {
-		return failLocalSandboxCreate(ctx, st, sb.ID, fmt.Errorf("put sandbox %q: %w", sb.ID, err))
-	}
-	doneAllocate(fmt.Sprintf("%s  ·  %d resource(s)", sb.ID, len(sb.Resources)))
-
-	// Collect full resource details (includes Allocate-time properties).
-	resources := make([]model.Resource, 0, len(sb.Resources))
-	for _, rid := range sb.Resources {
-		res, err := st.GetResource(ctx, rid)
-		if err == nil {
-			resources = append(resources, res)
-		}
-	}
-
-	// --- Replenish pools so preheat targets stay satisfied ---
-	for poolName := range needByPool {
-		label := fmt.Sprintf("Pool %s  replenishing", poolName)
-		spin, _ := boxySpinner.Start(label)
-		t0 := time.Now()
-		if err := pm.Reconcile(ctx, poolName); err != nil {
-			spin.Fail(err.Error())
-			return fmt.Errorf("reconcile pool %q after allocation: %w", poolName, err)
-		}
-		spin.Success(label + "  " + pterm.FgDarkGray.Sprintf("done  (%s)", time.Since(t0).Round(time.Millisecond)))
 	}
 
 	printConnectionInfo(sb, resources)
@@ -208,31 +86,140 @@ func sandboxCreate(ctx context.Context, opts sandboxCreateOpts) error {
 		}
 	}
 
-	pterm.FgDarkGray.Printfln("  boxy sandbox get %s", sb.ID)
-	pterm.FgDarkGray.Printfln("  boxy sandbox delete %s", sb.ID)
+	printSandboxCommands(sb.ID)
 	pterm.Println()
-
 	return nil
 }
 
-func failLocalSandboxCreate(ctx context.Context, st store.Store, sandboxID model.SandboxID, cause error) error {
-	if cause == nil {
-		return nil
+func loadSandboxSpec(path string) (boxyconfig.SandboxSpec, error) {
+	spec, err := boxyconfig.LoadSandboxFile(path)
+	if err != nil {
+		return boxyconfig.SandboxSpec{}, err
 	}
-	if st == nil || sandboxID == "" {
-		return cause
+	if strings.TrimSpace(spec.Name) == "" {
+		return boxyconfig.SandboxSpec{}, fmt.Errorf("sandbox spec name is required")
+	}
+	if len(spec.Resources) == 0 {
+		return boxyconfig.SandboxSpec{}, fmt.Errorf("sandbox spec resources is required")
+	}
+	for i := range spec.Resources {
+		res := spec.Resources[i]
+		if strings.TrimSpace(res.Pool) == "" {
+			return boxyconfig.SandboxSpec{}, fmt.Errorf("resources[%d].pool is required", i)
+		}
+		if res.Count <= 0 {
+			return boxyconfig.SandboxSpec{}, fmt.Errorf("resources[%d].count must be > 0", i)
+		}
+	}
+	return spec, nil
+}
+
+func compileSandboxRequests(spec boxyconfig.SandboxSpec, pools []model.Pool) ([]model.ResourceRequest, error) {
+	poolByName := make(map[model.PoolName]model.Pool, len(pools))
+	for _, pool := range pools {
+		poolByName[pool.Name] = pool
 	}
 
-	sb, err := st.GetSandbox(ctx, sandboxID)
-	if err != nil {
-		return cause
+	requests := make([]model.ResourceRequest, 0, len(spec.Resources))
+	for i := range spec.Resources {
+		res := spec.Resources[i]
+		poolName := model.PoolName(strings.TrimSpace(res.Pool))
+		pool, ok := poolByName[poolName]
+		if !ok {
+			return nil, fmt.Errorf("resources[%d].pool %q not found on server", i, res.Pool)
+		}
+		if pool.Inventory.ExpectedType == "" || pool.Inventory.ExpectedType == model.ResourceTypeUnknown {
+			return nil, fmt.Errorf("pool %q is missing expected resource type", pool.Name)
+		}
+		if strings.TrimSpace(string(pool.Inventory.ExpectedProfile)) == "" {
+			return nil, fmt.Errorf("pool %q is missing expected resource profile", pool.Name)
+		}
+
+		requests = append(requests, model.ResourceRequest{
+			Type:    pool.Inventory.ExpectedType,
+			Profile: pool.Inventory.ExpectedProfile,
+			Count:   res.Count,
+		})
 	}
-	sb.Status = model.SandboxStatusFailed
-	sb.Error = cause.Error()
-	if putErr := st.PutSandbox(ctx, sb); putErr != nil {
-		return fmt.Errorf("%w (also failed to mark sandbox %q failed: %v)", cause, sandboxID, putErr)
+
+	return requests, nil
+}
+
+func waitForSandboxReady(ctx context.Context, client *http.Client, base string, initial model.Sandbox) (model.Sandbox, error) {
+	spin, _ := boxySpinner.Start(fmt.Sprintf("Waiting for sandbox %q", initial.Name))
+	defer func() {
+		if spin.IsActive {
+			_ = spin.Stop()
+		}
+	}()
+
+	sb := initial
+	ticker := time.NewTicker(sandboxPollInterval)
+	defer ticker.Stop()
+
+	for {
+		switch sb.Status {
+		case model.SandboxStatusReady:
+			spin.Success(fmt.Sprintf("Waiting for sandbox %q  %s", sb.Name, pterm.FgDarkGray.Sprintf("%s  ·  %d resource(s)", sb.ID, len(sb.Resources))))
+			return sb, nil
+		case model.SandboxStatusFailed:
+			msg := strings.TrimSpace(sb.Error)
+			if msg == "" {
+				msg = "sandbox request failed"
+			}
+			spin.Fail(msg)
+			return sb, fmt.Errorf("sandbox %q failed: %s", sb.ID, msg)
+		}
+
+		select {
+		case <-ctx.Done():
+			spin.Fail("interrupted")
+			return sb, fmt.Errorf("sandbox %q created but wait was interrupted: %w", sb.ID, ctx.Err())
+		case <-ticker.C:
+		}
+
+		next, err := fetchJSON[model.Sandbox](ctx, client, base+"/api/v1/sandboxes/"+string(sb.ID))
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				spin.Fail("interrupted")
+				return sb, fmt.Errorf("sandbox %q created but wait was interrupted: %w", sb.ID, err)
+			}
+			spin.Fail(err.Error())
+			return sb, fmt.Errorf("wait for sandbox %q: %w", sb.ID, err)
+		}
+		sb = next
 	}
-	return cause
+}
+
+func hydrateSandboxResources(ctx context.Context, client *http.Client, base string, sb model.Sandbox) ([]model.Resource, error) {
+	resources := make([]model.Resource, 0, len(sb.Resources))
+	for _, rid := range sb.Resources {
+		res, err := fetchJSON[model.Resource](ctx, client, base+"/api/v1/resources/"+string(rid))
+		if err != nil {
+			var apiErr *apiError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+				continue
+			}
+			return nil, fmt.Errorf("get resource %q for sandbox %q: %w", rid, sb.ID, err)
+		}
+		resources = append(resources, res)
+	}
+	return resources, nil
+}
+
+func printAcceptedSandbox(sb model.Sandbox) {
+	pterm.Println()
+	pterm.Bold.Printfln("  Sandbox accepted")
+	pterm.Println()
+	pterm.Printfln("    id: %s", sb.ID)
+	pterm.Printfln("    name: %s", sb.Name)
+	pterm.Printfln("    status: %s", sb.Status)
+	pterm.Println()
+}
+
+func printSandboxCommands(id model.SandboxID) {
+	pterm.FgDarkGray.Printfln("  boxy sandbox get %s", id)
+	pterm.FgDarkGray.Printfln("  boxy sandbox delete %s", id)
 }
 
 // printConnectionInfo displays sandbox connection info once to the terminal.
@@ -377,73 +364,6 @@ func readSingleKey() (byte, error) {
 	return buf[0], nil
 }
 
-func upsertPool(ctx context.Context, st store.Store, desired model.Pool) error {
-	existing, err := st.GetPool(ctx, desired.Name)
-	if err != nil && err != store.ErrNotFound {
-		return fmt.Errorf("get pool %q: %w", desired.Name, err)
-	}
-	if err == nil {
-		// Preserve existing inventory to avoid orphaning resources on disk.
-		if existing.Inventory.ExpectedType == desired.Inventory.ExpectedType && existing.Inventory.ExpectedProfile == desired.Inventory.ExpectedProfile {
-			desired.Inventory.Resources = existing.Inventory.Resources
-		}
-	}
-	if err := st.PutPool(ctx, desired); err != nil {
-		return fmt.Errorf("put pool %q: %w", desired.Name, err)
-	}
-	return nil
-}
-
-func resolveConfigPath(explicitPath, sandboxFile string) (string, error) {
-	if explicitPath != "" {
-		return explicitPath, nil
-	}
-	if sandboxFile != "" {
-		dir := filepath.Dir(sandboxFile)
-		p, err := findConfigPathInDir(dir)
-		if err != nil {
-			return "", err
-		}
-		if p != "" {
-			return p, nil
-		}
-	}
-	wd, err := effectiveWD()
-	if err != nil {
-		return "", fmt.Errorf("get working directory: %w", err)
-	}
-	return findConfigPathInDir(wd)
-}
-
-func poolModelFromSpec(ps boxyconfig.PoolSpec) (model.Pool, error) {
-	name := model.PoolName(strings.TrimSpace(ps.Name))
-	if name == "" {
-		return model.Pool{}, fmt.Errorf("pool name is required")
-	}
-	expectedType, err := poolExpectedType(ps.Type)
-	if err != nil {
-		return model.Pool{}, fmt.Errorf("pool %q type invalid: %w", name, err)
-	}
-	pol := ps.EffectivePolicy()
-	return model.Pool{
-		Name: name,
-		Policies: model.PoolPolicies{
-			Preheat: model.PreheatPolicy{
-				MinReady: pol.Preheat.MinReady,
-				MaxTotal: pol.Preheat.MaxTotal,
-			},
-			Recycle: model.RecyclePolicy{
-				MaxAge: pol.Recycle.MaxAge,
-			},
-		},
-		Inventory: model.ResourceCollection{
-			ExpectedType:    expectedType,
-			ExpectedProfile: model.ResourceProfile(name),
-			Resources:       nil,
-		},
-	}, nil
-}
-
 func poolExpectedType(t string) (model.ResourceType, error) {
 	switch strings.TrimSpace(t) {
 	case "container", "docker":
@@ -457,50 +377,4 @@ func poolExpectedType(t string) (model.ResourceType, error) {
 	default:
 		return model.ResourceTypeUnknown, fmt.Errorf("unsupported pool type %q", t)
 	}
-}
-
-func ensureImplicitProviders(explicit []providersdk.Instance, pools []boxyconfig.PoolSpec) []providersdk.Instance {
-	out := make([]providersdk.Instance, 0, len(explicit)+2)
-	out = append(out, explicit...)
-
-	byName := make(map[string]providersdk.Instance, len(out))
-	for _, inst := range out {
-		byName[inst.Name] = inst
-	}
-
-	need := make(map[string]providersdk.Type)
-	for _, p := range pools {
-		name := strings.TrimSpace(p.Provider)
-		if name == "" && strings.TrimSpace(p.Type) == "docker" {
-			name = "docker-local"
-		}
-		if name == "" {
-			// Default provider for container pools.
-			name = "docker-local"
-		}
-		if _, exists := byName[name]; exists {
-			continue
-		}
-		need[name] = "docker"
-	}
-
-	for name, typ := range need {
-		if typ != "docker" {
-			continue
-		}
-		host := "unix:///var/run/docker.sock"
-		if name == "docker-remote" {
-			// Placeholder that satisfies schema validation; override later via explicit config.
-			host = "tcp://docker-host:2376"
-		}
-		out = append(out, providersdk.Instance{
-			Name: name,
-			Type: "docker",
-			Config: map[string]any{
-				"host": host,
-			},
-		})
-	}
-
-	return out
 }

--- a/internal/cli/sandbox_create.go
+++ b/internal/cli/sandbox_create.go
@@ -146,12 +146,19 @@ func compileSandboxRequests(spec boxyconfig.SandboxSpec, pools []model.Pool) ([]
 }
 
 func waitForSandboxReady(ctx context.Context, client *http.Client, base string, initial model.Sandbox) (model.Sandbox, error) {
-	spin, _ := boxySpinner.Start(fmt.Sprintf("Waiting for sandbox %q", initial.Name))
-	defer func() {
-		if spin.IsActive {
-			_ = spin.Stop()
-		}
-	}()
+	var (
+		spin       *pterm.SpinnerPrinter
+		useSpinner = useSpinnerOutput()
+	)
+	if useSpinner {
+		started, _ := boxySpinner.Start(fmt.Sprintf("Waiting for sandbox %q", initial.Name))
+		spin = started
+		defer func() {
+			if spin.IsActive {
+				_ = spin.Stop()
+			}
+		}()
+	}
 
 	sb := initial
 	ticker := time.NewTicker(sandboxPollInterval)
@@ -160,20 +167,33 @@ func waitForSandboxReady(ctx context.Context, client *http.Client, base string, 
 	for {
 		switch sb.Status {
 		case model.SandboxStatusReady:
-			spin.Success(fmt.Sprintf("Waiting for sandbox %q  %s", sb.Name, pterm.FgDarkGray.Sprintf("%s  ·  %d resource(s)", sb.ID, len(sb.Resources))))
+			msg := fmt.Sprintf("Waiting for sandbox %q  %s", sb.Name, pterm.FgDarkGray.Sprintf("%s  ·  %d resource(s)", sb.ID, len(sb.Resources)))
+			if useSpinner {
+				spin.Success(msg)
+			} else {
+				boxySuccessPrinter.Println(msg)
+			}
 			return sb, nil
 		case model.SandboxStatusFailed:
 			msg := strings.TrimSpace(sb.Error)
 			if msg == "" {
 				msg = "sandbox request failed"
 			}
-			spin.Fail(msg)
+			if useSpinner {
+				spin.Fail(msg)
+			} else {
+				boxyFailPrinter.Println(msg)
+			}
 			return sb, fmt.Errorf("sandbox %q failed: %s", sb.ID, msg)
 		}
 
 		select {
 		case <-ctx.Done():
-			spin.Fail("interrupted")
+			if useSpinner {
+				spin.Fail("interrupted")
+			} else {
+				boxyFailPrinter.Println("interrupted")
+			}
 			return sb, fmt.Errorf("sandbox %q created but wait was interrupted: %w", sb.ID, ctx.Err())
 		case <-ticker.C:
 		}
@@ -181,10 +201,18 @@ func waitForSandboxReady(ctx context.Context, client *http.Client, base string, 
 		next, err := fetchJSON[model.Sandbox](ctx, client, base+"/api/v1/sandboxes/"+string(sb.ID))
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				spin.Fail("interrupted")
+				if useSpinner {
+					spin.Fail("interrupted")
+				} else {
+					boxyFailPrinter.Println("interrupted")
+				}
 				return sb, fmt.Errorf("sandbox %q created but wait was interrupted: %w", sb.ID, err)
 			}
-			spin.Fail(err.Error())
+			if useSpinner {
+				spin.Fail(err.Error())
+			} else {
+				boxyFailPrinter.Println(err.Error())
+			}
 			return sb, fmt.Errorf("wait for sandbox %q: %w", sb.ID, err)
 		}
 		sb = next

--- a/internal/cli/sandbox_create_test.go
+++ b/internal/cli/sandbox_create_test.go
@@ -2,53 +2,322 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Geogboe/boxy/pkg/model"
-	"github.com/Geogboe/boxy/pkg/store"
 )
 
-func TestFailLocalSandboxCreate_MarksSandboxFailed(t *testing.T) {
-	t.Parallel()
+type sandboxCreateTestServer struct {
+	server *httptest.Server
 
-	st := store.NewMemoryStore()
-	ctx := context.Background()
-	sb := model.Sandbox{
-		ID:       "sb-1",
-		Name:     "local",
-		Status:   model.SandboxStatusPending,
-		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "web", Count: 1}},
-	}
-	if err := st.CreateSandbox(ctx, sb); err != nil {
-		t.Fatalf("CreateSandbox: %v", err)
+	mu                 sync.Mutex
+	pools              []model.Pool
+	createStatus       int
+	createErrorMessage string
+	createBody         string
+	createdSandbox     model.Sandbox
+	sandboxStates      []model.Sandbox
+	resources          map[string]model.Resource
+	createCalls        int
+	getSandboxCalls    int
+	getResourceCalls   int
+}
+
+func newSandboxCreateTestServer(t *testing.T) *sandboxCreateTestServer {
+	t.Helper()
+
+	ts := &sandboxCreateTestServer{
+		pools: []model.Pool{
+			{
+				Name: "web",
+				Inventory: model.ResourceCollection{
+					ExpectedType:    model.ResourceTypeContainer,
+					ExpectedProfile: "web",
+				},
+			},
+		},
+		createStatus:       http.StatusAccepted,
+		createErrorMessage: "sandbox requests are required",
+		createdSandbox: model.Sandbox{
+			ID:     "sb-create",
+			Name:   "lab",
+			Status: model.SandboxStatusPending,
+			Requests: []model.ResourceRequest{{
+				Type:    model.ResourceTypeContainer,
+				Profile: "web",
+				Count:   1,
+			}},
+		},
+		sandboxStates: []model.Sandbox{
+			{
+				ID:     "sb-create",
+				Name:   "lab",
+				Status: model.SandboxStatusPending,
+				Requests: []model.ResourceRequest{{
+					Type:    model.ResourceTypeContainer,
+					Profile: "web",
+					Count:   1,
+				}},
+			},
+			{
+				ID:     "sb-create",
+				Name:   "lab",
+				Status: model.SandboxStatusReady,
+				Requests: []model.ResourceRequest{{
+					Type:    model.ResourceTypeContainer,
+					Profile: "web",
+					Count:   1,
+				}},
+				Resources: []model.ResourceID{"res-1"},
+			},
+		},
+		resources: map[string]model.Resource{
+			"res-1": {
+				ID:      "res-1",
+				Type:    model.ResourceTypeContainer,
+				Profile: "web",
+				Properties: map[string]any{
+					"host": "127.0.0.1",
+					"port": 2222,
+				},
+			},
+		},
 	}
 
-	cause := failLocalSandboxCreate(ctx, st, sb.ID, context.DeadlineExceeded)
-	if cause == nil {
-		t.Fatal("expected original cause to be returned")
-	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/pools", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ts.pools)
+	})
+	mux.HandleFunc("POST /api/v1/sandboxes", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		ts.createCalls++
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		raw, _ := json.Marshal(body)
+		ts.createBody = string(raw)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(ts.createStatus)
+		if ts.createStatus >= http.StatusBadRequest {
+			_, _ = fmt.Fprintf(w, `{"error":"%s"}`, ts.createErrorMessage)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ts.createdSandbox)
+	})
+	mux.HandleFunc("GET /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		ts.getSandboxCalls++
+		w.Header().Set("Content-Type", "application/json")
+		if len(ts.sandboxStates) == 0 {
+			_ = json.NewEncoder(w).Encode(ts.createdSandbox)
+			return
+		}
+		state := ts.sandboxStates[0]
+		if len(ts.sandboxStates) > 1 {
+			ts.sandboxStates = ts.sandboxStates[1:]
+		}
+		_ = json.NewEncoder(w).Encode(state)
+	})
+	mux.HandleFunc("GET /api/v1/resources/{id}", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		ts.getResourceCalls++
+		id := r.PathValue("id")
+		res, ok := ts.resources[id]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(res)
+	})
 
-	got, err := st.GetSandbox(ctx, sb.ID)
+	ts.server = httptest.NewServer(mux)
+	return ts
+}
+
+func (ts *sandboxCreateTestServer) Close() {
+	ts.server.Close()
+}
+
+func writeSandboxSpec(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sandbox.yaml")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	return path
+}
+
+func TestSandboxCreate_BlockingSuccess(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	defer srv.Close()
+
+	specPath := writeSandboxSpec(t, "name: lab\nresources:\n  - pool: web\n    count: 1\n")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.server.URL, "create", "-f", specPath, "--no-env-file"})
+
+	output, err := captureSandboxStdout(t, func() error {
+		return cmd.ExecuteContext(context.Background())
+	})
 	if err != nil {
-		t.Fatalf("GetSandbox: %v", err)
+		t.Fatalf("execute: %v", err)
 	}
-	if got.Status != model.SandboxStatusFailed {
-		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusFailed)
+
+	for _, want := range []string{"Connection info", "SANDBOX_ID=sb-create", "SANDBOX_WEB_1_HOST=127.0.0.1", "boxy sandbox get sb-create"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want %q", output, want)
+		}
 	}
-	if !strings.Contains(got.Error, context.DeadlineExceeded.Error()) {
-		t.Fatalf("error = %q, want %q", got.Error, context.DeadlineExceeded)
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.createCalls != 1 {
+		t.Fatalf("createCalls = %d, want 1", srv.createCalls)
+	}
+	if srv.getSandboxCalls == 0 {
+		t.Fatal("expected polling to fetch sandbox state")
+	}
+	if srv.getResourceCalls != 1 {
+		t.Fatalf("getResourceCalls = %d, want 1", srv.getResourceCalls)
+	}
+	if !strings.Contains(srv.createBody, `"profile":"web"`) || !strings.Contains(srv.createBody, `"type":"container"`) {
+		t.Fatalf("createBody = %s, want compiled request payload", srv.createBody)
 	}
 }
 
-func TestFailLocalSandboxCreate_LeavesMissingSandboxAlone(t *testing.T) {
-	t.Parallel()
+func TestSandboxCreate_NoWait(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	defer srv.Close()
 
-	err := failLocalSandboxCreate(context.Background(), store.NewMemoryStore(), "missing", context.DeadlineExceeded)
-	if err == nil {
-		t.Fatal("expected original cause to be returned")
+	specPath := writeSandboxSpec(t, "name: lab\nresources:\n  - pool: web\n    count: 1\n")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.server.URL, "create", "-f", specPath, "--no-wait", "--no-env-file"})
+
+	output, err := captureSandboxStdout(t, func() error {
+		return cmd.ExecuteContext(context.Background())
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
 	}
-	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-		t.Fatalf("error = %q, want original cause", err)
+	if !strings.Contains(output, "Sandbox accepted") {
+		t.Fatalf("output = %q, want accepted message", output)
+	}
+	if strings.Contains(output, "Connection info") {
+		t.Fatalf("output = %q, did not expect connection info", output)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.getSandboxCalls != 0 {
+		t.Fatalf("getSandboxCalls = %d, want 0", srv.getSandboxCalls)
+	}
+	if srv.getResourceCalls != 0 {
+		t.Fatalf("getResourceCalls = %d, want 0", srv.getResourceCalls)
+	}
+}
+
+func TestSandboxCreate_UnknownPool(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	defer srv.Close()
+
+	specPath := writeSandboxSpec(t, "name: lab\nresources:\n  - pool: missing\n    count: 1\n")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.server.URL, "create", "-f", specPath})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `pool "missing" not found on server`) {
+		t.Fatalf("error = %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.createCalls != 0 {
+		t.Fatalf("createCalls = %d, want 0", srv.createCalls)
+	}
+}
+
+func TestSandboxCreate_FailedStatus(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	srv.sandboxStates = []model.Sandbox{
+		{
+			ID:     "sb-create",
+			Name:   "lab",
+			Status: model.SandboxStatusFailed,
+			Error:  "pool \"web\" has 0 ready resource(s), need 1",
+		},
+	}
+	defer srv.Close()
+
+	specPath := writeSandboxSpec(t, "name: lab\nresources:\n  - pool: web\n    count: 1\n")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.server.URL, "create", "-f", specPath})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `sandbox "sb-create" failed: pool "web" has 0 ready resource(s), need 1`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSandboxCreate_CreateAPIErrorIncludesServerMessage(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	srv.createStatus = http.StatusBadRequest
+	defer srv.Close()
+
+	specPath := writeSandboxSpec(t, "name: lab\nresources:\n  - pool: web\n    count: 1\n")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.server.URL, "create", "-f", specPath})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "sandbox requests are required") {
+		t.Fatalf("error = %v, want server message", err)
+	}
+}
+
+func TestWaitForSandboxReady_Interrupted(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := waitForSandboxReady(ctx, defaultAPIClient(), srv.server.URL, model.Sandbox{
+		ID:     "sb-create",
+		Name:   "lab",
+		Status: model.SandboxStatusPending,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `sandbox "sb-create" created but wait was interrupted`) {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
+	"golang.org/x/term"
 )
 
 var boxySuccessPrinter = pterm.PrefixPrinter{
@@ -33,6 +37,16 @@ var boxySpinner = pterm.SpinnerPrinter{
 // step starts a boxySpinner for a single CLI step and returns a done
 // callback that marks it successful with an optional detail string.
 func step(label string) func(detail string) {
+	if !useSpinnerOutput() {
+		return func(detail string) {
+			if detail != "" {
+				boxySuccessPrinter.Println(fmt.Sprintf("%s  %s", label, detail))
+				return
+			}
+			boxySuccessPrinter.Println(label)
+		}
+	}
+
 	spin, _ := boxySpinner.Start(label)
 	return func(detail string) {
 		if detail != "" {
@@ -41,4 +55,8 @@ func step(label string) func(detail string) {
 			spin.Success(label)
 		}
 	}
+}
+
+func useSpinnerOutput() bool {
+	return term.IsTerminal(int(os.Stdout.Fd())) //nolint:gosec // Fd() fits in int on all supported platforms.
 }


### PR DESCRIPTION
## Summary
- rewrite `boxy sandbox create` to use the daemon async API flow
- add `--no-wait` and keep connection info/env-file UX on the blocking path
- archive the retired local create flow and update docs/tests

Closes #67
Refs #89