### PR TITLE
fix(core): enforce pool max_total against allocated resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ docs/adr/             # Architecture Decision Records
 
 - Pools are homogeneous inventories of resources (see `pkg/model/pool.go` and `pkg/model/resource_collection.go`).
 - **Resources are single-use:** when a resource is allocated into a sandbox, it is never returned to a pool. (ADR-0002)
+- `model.Resource.OriginPool` is immutable provenance: it records which pool provisioned the resource, and `pool.preheat.max_total` is enforced against all non-destroyed resources with that origin, not just current ready inventory.
 - The daemon reconcile loop runs pool reconciliation both before and after sandbox fulfillment so preheat targets are restored in the same tick after allocations drain a pool.
 
 ### Sandboxes

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Boxy keeps pools of generic, ready-to-use resources warm ahead of time. When a u
 
 ## Core Domain Model
 
-**Resource** — A runtime record of a provisioned instance (VM, container, share, network, etc.). Has an ID, type, state, provider handle, and properties. Resources are single-use: once allocated to a sandbox they are never returned to a pool (ADR-0002). A resource does not carry a "spec" or "profile" — it is simply evidence that provisioning succeeded.
+**Resource** — A runtime record of a provisioned instance (VM, container, share, network, etc.). Has an ID, type, state, provider handle, and properties. Resources are single-use: once allocated to a sandbox they are never returned to a pool (ADR-0002). Resources also retain immutable pool provenance so the daemon can reason about capacity even after allocation removes them from ready inventory.
 
 **Pool** — A named, homogeneous inventory of pre-provisioned resources. Declared in config. Each pool carries its own provisioning config (`type` identifies the provider/driver, `config` is a driver-interpreted opaque blob) and policy (preheat, recycle). The pool IS the spec — there is no separate "blueprint", "template", or "spec" entity.
 
@@ -221,7 +221,7 @@ pools:
 policy:
   preheat:
     min_ready: N       # target number of ready resources
-    max_total: N       # hard cap
+    max_total: N       # hard cap across ready + allocated resources from this pool
   recycle:
     max_age: "168h"    # destroy and replace unused resources older than this
 ```
@@ -250,7 +250,7 @@ boxy sandbox create -f pentest-lab.sandbox.yaml
 boxy sandbox create -f pentest-lab.sandbox.yaml --no-wait
 ```
 
-The file-based path is the primary, repeatable, version-controlled way. The CLI compiles pool references from the spec into daemon API requests, submits them to `boxy serve`, and waits for a terminal sandbox status by default.
+The file-based path is the primary, repeatable, version-controlled way. The CLI compiles pool references from the spec into daemon API requests, submits them to `boxy serve`, and waits for a terminal sandbox status by default. If a matching pool has exhausted its `max_total` hard cap, the sandbox request fails with `status: "failed"` rather than provisioning beyond the cap.
 
 See [examples/](examples/) for complete configurations.
 

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +18,25 @@ type Clock interface {
 type realClock struct{}
 
 func (realClock) Now() time.Time { return time.Now().UTC() }
+
+type MaxTotalReachedError struct {
+	PoolName       model.PoolName
+	MaxTotal       int
+	CurrentTotal   int
+	ReadyCount     int
+	RequestedReady int
+}
+
+func (e *MaxTotalReachedError) Error() string {
+	return fmt.Sprintf(
+		"pool %q is at max_total %d (%d total, %d ready), cannot satisfy requested ready count %d",
+		e.PoolName,
+		e.MaxTotal,
+		e.CurrentTotal,
+		e.ReadyCount,
+		e.RequestedReady,
+	)
+}
 
 // Manager reconciles a pool's inventory against its policies.
 type Manager struct {
@@ -41,7 +61,7 @@ func (m *Manager) SetClock(c Clock) {
 
 // Reconcile performs one reconciliation pass for the pool.
 func (m *Manager) Reconcile(ctx context.Context, poolName model.PoolName) error {
-	return m.reconcile(ctx, poolName, 0)
+	return m.reconcile(ctx, poolName, 0, false)
 }
 
 // EnsureReady ensures the pool has at least minReady resources available,
@@ -50,10 +70,10 @@ func (m *Manager) EnsureReady(ctx context.Context, poolName model.PoolName, minR
 	if minReady <= 0 {
 		return nil
 	}
-	return m.reconcile(ctx, poolName, minReady)
+	return m.reconcile(ctx, poolName, minReady, true)
 }
 
-func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minReadyOverride int) error {
+func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minReadyOverride int, requireMinReady bool) error {
 	if m == nil {
 		return fmt.Errorf("pool manager is nil")
 	}
@@ -68,12 +88,14 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 	}
 
 	type observed struct {
-		pool model.Pool
-		now  time.Time
+		pool      model.Pool
+		resources []model.Resource
+		now       time.Time
 	}
 	type plan struct {
 		pool        model.Pool
 		stale       []model.Resource
+		now         time.Time
 		toProvision int
 		reason      string
 	}
@@ -84,7 +106,11 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 			if err != nil {
 				return observed{}, fmt.Errorf("get pool: %w", err)
 			}
-			return observed{pool: p, now: m.clock.Now()}, nil
+			resources, err := m.store.ListResources(ctx)
+			if err != nil {
+				return observed{}, fmt.Errorf("list resources: %w", err)
+			}
+			return observed{pool: p, resources: resources, now: m.clock.Now()}, nil
 		}),
 		Evaluator: policycontroller.EvaluatorFunc[observed, plan](func(ctx context.Context, obs observed) (policycontroller.Decision[plan], error) {
 			_ = ctx
@@ -96,12 +122,22 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 			}
 			p.Inventory.Resources = kept
 
+			readyCount := countReadyResources(p.Inventory.Resources)
+			staleIDs := resourceIDSet(stale)
+			totalCount := countTrackedResources(p.Name, obs.resources, p.Inventory.Resources, staleIDs)
+
 			effectiveMinReady := p.Policies.Preheat.MinReady
 			if minReadyOverride > effectiveMinReady {
 				effectiveMinReady = minReadyOverride
 			}
 
-			toProv := computeToProvision(p, effectiveMinReady)
+			if requireMinReady {
+				if capErr := maxTotalShortfall(p.Name, p.Policies.Preheat.MaxTotal, totalCount, readyCount, effectiveMinReady); capErr != nil {
+					return policycontroller.Decision[plan]{}, capErr
+				}
+			}
+
+			toProv := computeToProvision(p, effectiveMinReady, totalCount)
 			reason := "noop"
 			should := false
 			if len(stale) > 0 || toProv > 0 {
@@ -114,6 +150,7 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 				Plan: plan{
 					pool:        p,
 					stale:       stale,
+					now:         obs.now,
 					toProvision: toProv,
 					reason:      reason,
 				},
@@ -127,12 +164,20 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 				if err := m.provisioner.Destroy(ctx, p, res); err != nil {
 					return fmt.Errorf("destroy stale resource %q in pool %q: %w", res.ID, p.Name, err)
 				}
+				res.State = model.ResourceStateDestroyed
+				res.UpdatedAt = pl.now
+				if err := m.store.PutResource(ctx, res); err != nil {
+					return fmt.Errorf("mark stale resource %q destroyed: %w", res.ID, err)
+				}
 			}
 
 			for i := 0; i < pl.toProvision; i++ {
 				res, err := m.provisioner.Provision(ctx, p)
 				if err != nil {
 					return fmt.Errorf("provision resource for pool %q: %w", p.Name, err)
+				}
+				if res.OriginPool == "" {
+					res.OriginPool = p.Name
 				}
 				if err := p.Inventory.Add(res); err != nil {
 					return fmt.Errorf("add resource to pool %q inventory: %w", p.Name, err)
@@ -150,6 +195,12 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 	}
 
 	_, err := ctrl.Reconcile(ctx)
+	if err != nil {
+		var capErr *MaxTotalReachedError
+		if errors.As(err, &capErr) {
+			return capErr
+		}
+	}
 	return err
 }
 
@@ -183,26 +234,20 @@ func computeStale(p model.Pool, now time.Time) (stale []model.Resource, kept []m
 	return stale, kept, nil
 }
 
-func computeToProvision(p model.Pool, minReady int) int {
+func computeToProvision(p model.Pool, minReady int, totalCount int) int {
 	maxTotal := p.Policies.Preheat.MaxTotal
 	if minReady <= 0 {
 		return 0
 	}
 
-	readyCount := 0
-	for _, res := range p.Inventory.Resources {
-		if res.State == model.ResourceStateReady {
-			readyCount++
-		}
-	}
-
+	readyCount := countReadyResources(p.Inventory.Resources)
 	need := minReady - readyCount
 	if need <= 0 {
 		return 0
 	}
 
 	if maxTotal > 0 {
-		avail := maxTotal - len(p.Inventory.Resources)
+		avail := maxTotal - totalCount
 		if avail <= 0 {
 			return 0
 		}
@@ -212,4 +257,82 @@ func computeToProvision(p model.Pool, minReady int) int {
 	}
 
 	return need
+}
+
+func countReadyResources(resources []model.Resource) int {
+	readyCount := 0
+	for _, res := range resources {
+		if res.State == model.ResourceStateReady {
+			readyCount++
+		}
+	}
+	return readyCount
+}
+
+func resourceIDSet(resources []model.Resource) map[model.ResourceID]struct{} {
+	ids := make(map[model.ResourceID]struct{}, len(resources))
+	for _, res := range resources {
+		if res.ID == "" {
+			continue
+		}
+		ids[res.ID] = struct{}{}
+	}
+	return ids
+}
+
+func countTrackedResources(
+	poolName model.PoolName,
+	resources []model.Resource,
+	inventory []model.Resource,
+	excludeIDs map[model.ResourceID]struct{},
+) int {
+	inventoryIDs := resourceIDSet(inventory)
+	total := 0
+	for _, res := range resources {
+		if res.ID == "" {
+			continue
+		}
+		if _, excluded := excludeIDs[res.ID]; excluded {
+			continue
+		}
+		if res.State == model.ResourceStateDestroyed {
+			continue
+		}
+		if res.OriginPool == poolName {
+			total++
+			continue
+		}
+		if res.OriginPool == "" {
+			if _, ok := inventoryIDs[res.ID]; ok {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+func maxTotalShortfall(
+	poolName model.PoolName,
+	maxTotal int,
+	totalCount int,
+	readyCount int,
+	requestedReady int,
+) error {
+	if maxTotal <= 0 || requestedReady <= 0 {
+		return nil
+	}
+	availableToProvision := maxTotal - totalCount
+	if availableToProvision < 0 {
+		availableToProvision = 0
+	}
+	if readyCount+availableToProvision >= requestedReady {
+		return nil
+	}
+	return &MaxTotalReachedError{
+		PoolName:       poolName,
+		MaxTotal:       maxTotal,
+		CurrentTotal:   totalCount,
+		ReadyCount:     readyCount,
+		RequestedReady: requestedReady,
+	}
 }

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -110,4 +110,116 @@ func TestManager_Reconcile_RecycleStale(t *testing.T) {
 	if updated.Inventory.Resources[0].ID == "res_old" {
 		t.Fatalf("expected old resource to be recycled")
 	}
+
+	oldAfter, err := st.GetResource(context.Background(), old.ID)
+	if err != nil {
+		t.Fatalf("get old resource: %v", err)
+	}
+	if oldAfter.State != model.ResourceStateDestroyed {
+		t.Fatalf("old resource state = %q, want %q", oldAfter.State, model.ResourceStateDestroyed)
+	}
+}
+
+func TestManager_EnsureReady_RespectsMaxTotalAcrossAllocatedResources(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	allocated := model.Resource{
+		ID:         "res_allocated",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		Provider:   model.ProviderRef{Name: "prov_1"},
+		State:      model.ResourceStateAllocated,
+		CreatedAt:  time.Unix(1000, 0).UTC(),
+		UpdatedAt:  time.Unix(1000, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, allocated); err != nil {
+		t.Fatalf("put allocated resource: %v", err)
+	}
+	pool := model.Pool{
+		Name: "p1",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 1, MaxTotal: 1},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+
+	err := mgr.EnsureReady(ctx, "p1", 1)
+	if err == nil {
+		t.Fatal("expected ensure ready to fail at max_total")
+	}
+	if err.Error() != `pool "p1" is at max_total 1 (1 total, 0 ready), cannot satisfy requested ready count 1` {
+		t.Fatalf("ensure ready error = %v", err)
+	}
+
+	updated, err := st.GetPool(ctx, "p1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(updated.Inventory.Resources) != 0 {
+		t.Fatalf("inventory len = %d, want 0", len(updated.Inventory.Resources))
+	}
+	if prov.n != 0 {
+		t.Fatalf("provision count = %d, want 0", prov.n)
+	}
+}
+
+func TestManager_Reconcile_IgnoresDestroyedResourcesWhenApplyingMaxTotal(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	destroyed := model.Resource{
+		ID:         "res_destroyed",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		Provider:   model.ProviderRef{Name: "prov_1"},
+		State:      model.ResourceStateDestroyed,
+		CreatedAt:  time.Unix(1000, 0).UTC(),
+		UpdatedAt:  time.Unix(1001, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, destroyed); err != nil {
+		t.Fatalf("put destroyed resource: %v", err)
+	}
+	pool := model.Pool{
+		Name: "p1",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 1, MaxTotal: 1},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updated, err := st.GetPool(ctx, "p1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(updated.Inventory.Resources) != 1 {
+		t.Fatalf("inventory len = %d, want 1", len(updated.Inventory.Resources))
+	}
+	if prov.n != 1 {
+		t.Fatalf("provision count = %d, want 1", prov.n)
+	}
 }

--- a/internal/pool/provisioner_agent.go
+++ b/internal/pool/provisioner_agent.go
@@ -52,6 +52,7 @@ func (ap *AgentProvisioner) Provision(ctx context.Context, pool model.Pool) (mod
 		ID:         model.ResourceID(res.ID),
 		Type:       pool.Inventory.ExpectedType,
 		Profile:    pool.Inventory.ExpectedProfile,
+		OriginPool: pool.Name,
 		Provider:   model.ProviderRef{Name: string(driverType)},
 		State:      model.ResourceStateReady,
 		Properties: props,

--- a/internal/pool/provisioner_driver.go
+++ b/internal/pool/provisioner_driver.go
@@ -55,6 +55,7 @@ func (dp *DriverProvisioner) Provision(ctx context.Context, pool model.Pool) (mo
 		ID:         model.ResourceID(res.ID),
 		Type:       pool.Inventory.ExpectedType,
 		Profile:    pool.Inventory.ExpectedProfile,
+		OriginPool: pool.Name,
 		Provider:   model.ProviderRef{Name: providerName},
 		State:      model.ResourceStateReady,
 		Properties: props,

--- a/internal/sandbox/fulfillment_test.go
+++ b/internal/sandbox/fulfillment_test.go
@@ -45,13 +45,14 @@ func (p *fakeFulfillProvisioner) Provision(ctx context.Context, pl model.Pool) (
 	}
 	p.nextID++
 	return model.Resource{
-		ID:        model.ResourceID(fmt.Sprintf("res-%d", p.nextID)),
-		Type:      pl.Inventory.ExpectedType,
-		Profile:   pl.Inventory.ExpectedProfile,
-		Provider:  model.ProviderRef{Name: "fake"},
-		State:     model.ResourceStateReady,
-		CreatedAt: time.Unix(int64(1000+p.nextID), 0).UTC(),
-		UpdatedAt: time.Unix(int64(1000+p.nextID), 0).UTC(),
+		ID:         model.ResourceID(fmt.Sprintf("res-%d", p.nextID)),
+		Type:       pl.Inventory.ExpectedType,
+		Profile:    pl.Inventory.ExpectedProfile,
+		OriginPool: pl.Name,
+		Provider:   model.ProviderRef{Name: "fake"},
+		State:      model.ResourceStateReady,
+		CreatedAt:  time.Unix(int64(1000+p.nextID), 0).UTC(),
+		UpdatedAt:  time.Unix(int64(1000+p.nextID), 0).UTC(),
 	}, nil
 }
 
@@ -171,6 +172,68 @@ func TestFulfiller_ReconcilePending_ProvisionsResourcesBeforeAllocation(t *testi
 	}
 	if prov.nextID != 1 {
 		t.Fatalf("provision count = %d, want 1", prov.nextID)
+	}
+}
+
+func TestFulfiller_ReconcilePending_FailsWhenPoolHitsMaxTotal(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	allocated := model.Resource{
+		ID:         "res-allocated",
+		Type:       model.ResourceTypeContainer,
+		Profile:    "kali",
+		OriginPool: "kali",
+		Provider:   model.ProviderRef{Name: "fake"},
+		State:      model.ResourceStateAllocated,
+		CreatedAt:  time.Unix(1, 0).UTC(),
+		UpdatedAt:  time.Unix(1, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, allocated); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MaxTotal: 1},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1}},
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	prov := &fakeFulfillProvisioner{}
+	f := NewFulfiller(st, pool.New(st, prov), New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if got.Status != model.SandboxStatusFailed {
+		t.Fatalf("status = %q, want %q", got.Status, model.SandboxStatusFailed)
+	}
+	if !strings.Contains(got.Error, `pool "kali" is at max_total 1`) {
+		t.Fatalf("error = %q, want max_total failure", got.Error)
+	}
+	if prov.nextID != 0 {
+		t.Fatalf("provision count = %d, want 0", prov.nextID)
 	}
 }
 

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -113,6 +113,9 @@ func (m *Manager) AddFromPool(
 		if res.ID == "" {
 			return model.Sandbox{}, fmt.Errorf("selected resource has empty id")
 		}
+		if res.OriginPool == "" {
+			res.OriginPool = pool.Name
+		}
 		if m.allocator != nil {
 			extra, err := m.allocator.Allocate(ctx, pool, res)
 			if err != nil {
@@ -214,6 +217,9 @@ func (m *Manager) CreateFromPool(
 	for _, res := range selected {
 		if res.ID == "" {
 			return model.Sandbox{}, fmt.Errorf("selected resource has empty id")
+		}
+		if res.OriginPool == "" {
+			res.OriginPool = pool.Name
 		}
 		if m.allocator != nil {
 			extra, err := m.allocator.Allocate(ctx, pool, res)

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -42,6 +42,11 @@ type Resource struct {
 	// Example: vm "win-2022", container "ubuntu-2204".
 	Profile ResourceProfile `json:"profile,omitempty" yaml:"profile,omitempty"`
 
+	// OriginPool is the immutable pool that originally provisioned this resource.
+	// It is used for pool-level capacity accounting even after allocation removes
+	// the resource from ready inventory.
+	OriginPool PoolName `json:"origin_pool,omitempty" yaml:"origin_pool,omitempty"`
+
 	// Provider identifies the external system instance this resource belongs to.
 	Provider ProviderRef `json:"provider" yaml:"provider"`
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -209,6 +209,40 @@ func testStoreSandboxFieldsRoundTrip(t *testing.T, newStore storeFactory) {
 	})
 }
 
+func testStoreResourceFieldsRoundTrip(t *testing.T, newStore storeFactory) {
+	t.Helper()
+
+	t.Run("Resource_fields_round_trip", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		s := newStore(t)
+
+		want := model.Resource{
+			ID:         "res-origin",
+			Type:       model.ResourceTypeContainer,
+			Profile:    "web",
+			OriginPool: "web",
+			Provider:   model.ProviderRef{Name: "docker"},
+			State:      model.ResourceStateAllocated,
+		}
+
+		if err := s.PutResource(ctx, want); err != nil {
+			t.Fatalf("PutResource: %v", err)
+		}
+
+		got, err := s.GetResource(ctx, want.ID)
+		if err != nil {
+			t.Fatalf("GetResource: %v", err)
+		}
+		if got.OriginPool != want.OriginPool {
+			t.Fatalf("origin_pool = %q, want %q", got.OriginPool, want.OriginPool)
+		}
+		if got.State != want.State {
+			t.Fatalf("state = %q, want %q", got.State, want.State)
+		}
+	})
+}
+
 var memoryFactory = func(t *testing.T) store.Store {
 	return store.NewMemoryStore()
 }
@@ -250,4 +284,14 @@ func TestMemoryStore_SandboxFieldsRoundTrip(t *testing.T) {
 func TestDiskStore_SandboxFieldsRoundTrip(t *testing.T) {
 	t.Parallel()
 	testStoreSandboxFieldsRoundTrip(t, diskFactory)
+}
+
+func TestMemoryStore_ResourceFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	testStoreResourceFieldsRoundTrip(t, memoryFactory)
+}
+
+func TestDiskStore_ResourceFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	testStoreResourceFieldsRoundTrip(t, diskFactory)
 }


### PR DESCRIPTION
## Summary
- enforce pool max_total against all non-destroyed resources provisioned by a pool, not just ready inventory
- add immutable resource origin provenance for capacity accounting
- fail sandbox fulfillment explicitly when a request would exceed the hard cap

## Validation
- task fmt
- go test -race -short ./...
- go test ./scripts -count=1
- go build ./cmd/boxy
- golangci-lint run ./...
- live daemon smoke test with max_total=1: first sandbox ready, second sandbox failed without overprovisioning

Closes #83