### PR TITLE
fix(docker): auto-pull missing pool images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ docs/adr/             # Architecture Decision Records
 
 - Pools are homogeneous inventories of resources (see `pkg/model/pool.go` and `pkg/model/resource_collection.go`).
 - **Resources are single-use:** when a resource is allocated into a sandbox, it is never returned to a pool. (ADR-0002)
+- Docker pool provisioning auto-pulls a configured image when it is missing locally; first-run Docker pools should not require a manual `docker pull`.
 - `model.Resource.OriginPool` is immutable provenance: it records which pool provisioned the resource, and `pool.preheat.max_total` is enforced against all non-destroyed resources with that origin, not just current ready inventory.
 - The daemon reconcile loop runs pool reconciliation both before and after sandbox fulfillment so preheat targets are restored in the same tick after allocations drain a pool.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Boxy keeps pools of generic, ready-to-use resources warm ahead of time. When a u
 
 **Provider** — An external system that provides resources (Docker, Hyper-V, Podman, VMware, etc.). Providers have a type that maps to a driver. Provider connection details (socket, host, certs) are owned by the agent, not the server. Drivers auto-discover their environment where possible.
 
-**Driver** — Code that knows how to talk to a specific provider type. Interprets pool provisioning config. Lives in `pkg/providersdk/drivers/`. Drivers auto-discover their environment (e.g., Docker checks for local socket, Hyper-V discovers via PowerShell). A pool's `type` field maps directly to a driver (e.g., `type: docker` → Docker driver, `type: hyperv` → Hyper-V driver).
+**Driver** — Code that knows how to talk to a specific provider type. Interprets pool provisioning config. Lives in `pkg/providersdk/drivers/`. Drivers auto-discover their environment (e.g., Docker checks for local socket, Hyper-V discovers via PowerShell). A pool's `type` field maps directly to a driver (e.g., `type: docker` → Docker driver, `type: hyperv` → Hyper-V driver). Docker pools automatically pull a missing image on first provision instead of requiring a manual `docker pull`.
 
 **Agent** — The runtime entity that executes provider operations using drivers. Can be:
 - **Embedded (local):** runs inside `boxy serve`, handles providers declared in `server.providers`.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Geogboe/rog v0.5.0
+	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -20,13 +21,13 @@ require (
 	atomicgo.dev/cursor v0.2.0 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-ntlmssp v0.1.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/containerd/console v1.0.5 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmC
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -198,6 +200,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/providersdk/providers/docker/driver.go
+++ b/pkg/providersdk/providers/docker/driver.go
@@ -13,10 +13,13 @@ import (
 	"strconv"
 	"strings"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -27,6 +30,8 @@ import (
 // dockerClient is the minimal Docker API surface used by this driver.
 // *client.Client satisfies this interface; tests inject a mock.
 type dockerClient interface {
+	ImageInspect(ctx context.Context, imageID string, inspectOpts ...client.ImageInspectOption) (imagetypes.InspectResponse, error)
+	ImagePull(ctx context.Context, refStr string, options imagetypes.PullOptions) (io.ReadCloser, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
@@ -67,6 +72,9 @@ func (d *Driver) Create(ctx context.Context, cfg any) (*providersdk.Resource, er
 	}
 	if strings.TrimSpace(cc.Image) == "" {
 		return nil, fmt.Errorf("config.image is required")
+	}
+	if err := d.ensureImageAvailable(ctx, cc.Image); err != nil {
+		return nil, err
 	}
 
 	command := toStringSlice(cc.Command)
@@ -156,6 +164,27 @@ func (d *Driver) Create(ctx context.Context, cfg any) (*providersdk.Resource, er
 			"image":          cc.Image,
 		},
 	}, nil
+}
+
+func (d *Driver) ensureImageAvailable(ctx context.Context, ref string) error {
+	if _, err := d.cli.ImageInspect(ctx, ref); err == nil {
+		return nil
+	} else if !cerrdefs.IsNotFound(err) {
+		return fmt.Errorf("docker ImageInspect %q: %w", ref, err)
+	}
+
+	stream, err := d.cli.ImagePull(ctx, ref, imagetypes.PullOptions{})
+	if err != nil {
+		return fmt.Errorf("docker ImagePull %q: %w", ref, err)
+	}
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	if err := jsonmessage.DisplayJSONMessagesStream(stream, io.Discard, 0, false, nil); err != nil {
+		return fmt.Errorf("docker ImagePull %q: %w", ref, err)
+	}
+	return nil
 }
 
 func (d *Driver) Read(ctx context.Context, id string) (*providersdk.ResourceStatus, error) {

--- a/pkg/providersdk/providers/docker/driver_test.go
+++ b/pkg/providersdk/providers/docker/driver_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/Geogboe/boxy/pkg/providersdk"
@@ -21,6 +23,8 @@ import (
 
 // mockDockerClient is a test double for dockerClient.
 type mockDockerClient struct {
+	imageInspect         func(ctx context.Context, imageID string, inspectOpts ...client.ImageInspectOption) (imagetypes.InspectResponse, error)
+	imagePull            func(ctx context.Context, refStr string, options imagetypes.PullOptions) (io.ReadCloser, error)
 	containerCreate      func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	containerStart       func(ctx context.Context, containerID string, options container.StartOptions) error
 	containerInspect     func(ctx context.Context, containerID string) (container.InspectResponse, error)
@@ -31,6 +35,18 @@ type mockDockerClient struct {
 	containerRemove      func(ctx context.Context, containerID string, options container.RemoveOptions) error
 }
 
+func (m *mockDockerClient) ImageInspect(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (imagetypes.InspectResponse, error) {
+	if m.imageInspect != nil {
+		return m.imageInspect(ctx, imageID, opts...)
+	}
+	return imagetypes.InspectResponse{}, nil
+}
+func (m *mockDockerClient) ImagePull(ctx context.Context, ref string, opts imagetypes.PullOptions) (io.ReadCloser, error) {
+	if m.imagePull != nil {
+		return m.imagePull(ctx, ref, opts)
+	}
+	return io.NopCloser(strings.NewReader("")), nil
+}
 func (m *mockDockerClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
 	return m.containerCreate(ctx, config, hostConfig, networkingConfig, platform, containerName)
 }
@@ -97,6 +113,25 @@ func pipeHijack(data []byte) types.HijackedResponse {
 	}
 }
 
+type notFoundError struct{ msg string }
+
+func (e notFoundError) Error() string { return e.msg }
+func (notFoundError) NotFound()       {}
+
+type trackingReadCloser struct {
+	reader io.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
 // --- Create ---
 
 func TestDriver_Create_HappyPath(t *testing.T) {
@@ -129,6 +164,121 @@ func TestDriver_Create_HappyPath(t *testing.T) {
 	}
 	if res.ConnectionInfo["image"] != "alpine:latest" {
 		t.Errorf("image = %q, want alpine:latest", res.ConnectionInfo["image"])
+	}
+}
+
+func TestDriver_Create_PullsMissingImage(t *testing.T) {
+	const imageRef = "alpine:latest"
+
+	inspectCalls := 0
+	pullCalls := 0
+	createCalls := 0
+	stream := &trackingReadCloser{
+		reader: strings.NewReader("{\"status\":\"Pulled\"}\n"),
+	}
+	mock := &mockDockerClient{
+		imageInspect: func(_ context.Context, got string, _ ...client.ImageInspectOption) (imagetypes.InspectResponse, error) {
+			inspectCalls++
+			if got != imageRef {
+				t.Errorf("inspect image = %q, want %q", got, imageRef)
+			}
+			return imagetypes.InspectResponse{}, notFoundError{msg: "missing image"}
+		},
+		imagePull: func(_ context.Context, got string, _ imagetypes.PullOptions) (io.ReadCloser, error) {
+			pullCalls++
+			if got != imageRef {
+				t.Errorf("pull image = %q, want %q", got, imageRef)
+			}
+			return stream, nil
+		},
+		containerCreate: func(_ context.Context, _ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ *ocispec.Platform, _ string) (container.CreateResponse, error) {
+			createCalls++
+			return container.CreateResponse{ID: "abc123def456"}, nil
+		},
+		containerStart: func(_ context.Context, _ string, _ container.StartOptions) error { return nil },
+		containerInspect: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return runningInspect("abc123def456", "boxy-abc123"), nil
+		},
+	}
+
+	d := &Driver{cli: mock}
+	if _, err := d.Create(context.Background(), &CreateConfig{Image: imageRef}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("inspect calls = %d, want 1", inspectCalls)
+	}
+	if pullCalls != 1 {
+		t.Fatalf("pull calls = %d, want 1", pullCalls)
+	}
+	if createCalls != 1 {
+		t.Fatalf("create calls = %d, want 1", createCalls)
+	}
+	if !stream.closed {
+		t.Fatal("expected image pull stream to be closed")
+	}
+}
+
+func TestDriver_Create_ImageInspectError(t *testing.T) {
+	mock := &mockDockerClient{
+		imageInspect: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (imagetypes.InspectResponse, error) {
+			return imagetypes.InspectResponse{}, fmt.Errorf("docker daemon unavailable")
+		},
+	}
+
+	d := &Driver{cli: mock}
+	_, err := d.Create(context.Background(), &CreateConfig{Image: "alpine:latest"})
+	if err == nil {
+		t.Fatal("expected inspect error")
+	}
+	if !strings.Contains(err.Error(), `docker ImageInspect "alpine:latest"`) {
+		t.Fatalf("error = %q, want image inspect context", err)
+	}
+}
+
+func TestDriver_Create_ImagePullError(t *testing.T) {
+	mock := &mockDockerClient{
+		imageInspect: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (imagetypes.InspectResponse, error) {
+			return imagetypes.InspectResponse{}, notFoundError{msg: "missing image"}
+		},
+		imagePull: func(_ context.Context, _ string, _ imagetypes.PullOptions) (io.ReadCloser, error) {
+			return nil, fmt.Errorf("registry timeout")
+		},
+	}
+
+	d := &Driver{cli: mock}
+	_, err := d.Create(context.Background(), &CreateConfig{Image: "alpine:latest"})
+	if err == nil {
+		t.Fatal("expected pull error")
+	}
+	if !strings.Contains(err.Error(), `docker ImagePull "alpine:latest": registry timeout`) {
+		t.Fatalf("error = %q, want image pull context", err)
+	}
+}
+
+func TestDriver_Create_ImagePullStreamError(t *testing.T) {
+	stream := &trackingReadCloser{
+		reader: strings.NewReader("{\"errorDetail\":{\"message\":\"pull failed\"},\"error\":\"pull failed\"}\n"),
+	}
+	mock := &mockDockerClient{
+		imageInspect: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (imagetypes.InspectResponse, error) {
+			return imagetypes.InspectResponse{}, notFoundError{msg: "missing image"}
+		},
+		imagePull: func(_ context.Context, _ string, _ imagetypes.PullOptions) (io.ReadCloser, error) {
+			return stream, nil
+		},
+	}
+
+	d := &Driver{cli: mock}
+	_, err := d.Create(context.Background(), &CreateConfig{Image: "alpine:latest"})
+	if err == nil {
+		t.Fatal("expected pull stream error")
+	}
+	if !strings.Contains(err.Error(), `docker ImagePull "alpine:latest": pull failed`) {
+		t.Fatalf("error = %q, want JSON stream pull error", err)
+	}
+	if !stream.closed {
+		t.Fatal("expected image pull stream to be closed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- auto-pull missing Docker pool images before container create
- surface pull-stream errors instead of stalling silently
- add driver coverage for inspect/pull error paths

## Testing
- go test -race -short ./...
- go test ./scripts -count=1
- go build ./cmd/boxy
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...
- live daemon smoke test with missing nginx:1.27.5-alpine3.21 image

Closes #80