### PR TITLE
fix: validate pool types during config validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ When decisions are made, save them as ADR documents in /docs/adr. This is a livi
 
 - Primary developer has an OOP background — write idiomatic Go (composition over inheritance) while respecting the project's values.
 - Don't think about "simple for v1" — I like to think about the entire architecture when designing personal experimental projects like this. Design for sound, maintainable architecture even if features aren't strictly needed for v1.
+- Look for clear interface contracts and separation of concerns. If a package is doing too much, consider how to split it up or abstract responsibilities. Make these abstract responsibilities reusable and composable where it makes sense and in public pkg/, but avoid premature generalization. A public package shouldn't feel coupled to the internal application structure it should completely usable outside of boxy. See existing `agentsdk` and `providersdk` packages for examples of this approach. These packages define general concepts like "Agent" and "Driver" that are implemented by the internal application but could also be used by external projects without depending on boxy-specific types or workflows. Developing this way also ensure we are only focusing on one problem at a time. For example, when working on the agent system, we can focus on defining a clean Agent interface and implementation without worrying about how it will be used in the daemon or CLI until we have a solid design for the agent itself.
 
 ## Taskfile
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -58,6 +58,9 @@ func runConfigValidate(ctx context.Context, opts configValidateOpts) error {
 	if err := reg.ValidateInstances(ctx, cfg.Providers); err != nil {
 		return fmt.Errorf("validate providers: %w", err)
 	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
 
 	fmt.Println("config OK")
 	return nil

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -40,6 +40,30 @@ func TestConfigValidate_bad_config(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_invalid_pool_type(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "boxy.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+pools:
+  - name: test
+    type: badtype
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"config", "validate", "--config", cfgPath})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid pool type")
+	}
+	if got, want := err.Error(), `pool "test" type invalid: unsupported pool type "badtype"`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
 func TestConfigValidate_missing_file(t *testing.T) {
 	t.Parallel()
 	cmd := NewRootCommand()

--- a/internal/cli/sandbox_create.go
+++ b/internal/cli/sandbox_create.go
@@ -391,18 +391,3 @@ func readSingleKey() (byte, error) {
 	}
 	return buf[0], nil
 }
-
-func poolExpectedType(t string) (model.ResourceType, error) {
-	switch strings.TrimSpace(t) {
-	case "container", "docker":
-		return model.ResourceTypeContainer, nil
-	case "vm":
-		return model.ResourceTypeVM, nil
-	case "share":
-		return model.ResourceTypeShare, nil
-	case "":
-		return model.ResourceTypeContainer, nil
-	default:
-		return model.ResourceTypeUnknown, fmt.Errorf("unsupported pool type %q", t)
-	}
-}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -85,6 +85,9 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 	if err := reg.ValidateInstances(ctx, cfg.Providers); err != nil {
 		return fmt.Errorf("validate providers: %w", err)
 	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
 	doneValidate(fmt.Sprintf("%d configured", len(cfg.Providers)))
 
 	// Build lookup maps for the DriverProvisioner.
@@ -301,7 +304,7 @@ func serveReconcilePass(
 // poolSpecToModel converts a config PoolSpec into a runtime model.Pool.
 // Initializes the pool's inventory with the expected type and profile.
 func poolSpecToModel(spec boxyconfig.PoolSpec) (model.Pool, error) {
-	expectedType, err := poolExpectedType(spec.Type)
+	expectedType, err := boxyconfig.ResolvePoolExpectedType(spec.Type)
 	if err != nil {
 		return model.Pool{}, fmt.Errorf("pool %q type invalid: %w", spec.Name, err)
 	}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	boxyconfig "github.com/Geogboe/boxy/internal/config"
 	"github.com/Geogboe/boxy/pkg/model"
 )
 
@@ -111,5 +112,17 @@ func TestOpenServeStore_PersistsStateAcrossReopen(t *testing.T) {
 	}
 	if got.ID != sb.ID || got.Status != model.SandboxStatusPending {
 		t.Fatalf("sandbox = %+v, want pending sandbox %q", got, sb.ID)
+	}
+}
+
+func TestPoolSpecToModel_invalid_pool_type(t *testing.T) {
+	t.Parallel()
+
+	_, err := poolSpecToModel(boxyconfig.PoolSpec{Name: "test", Type: "badtype"})
+	if err == nil {
+		t.Fatal("poolSpecToModel() error = nil, want invalid pool type")
+	}
+	if got, want := err.Error(), `pool "test" type invalid: unsupported pool type "badtype"`; got != want {
+		t.Fatalf("poolSpecToModel() error = %q, want %q", got, want)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/providersdk"
 	"gopkg.in/yaml.v3"
 )
@@ -98,4 +100,28 @@ func ensureJSONEOF(dec *json.Decoder) error {
 		return fmt.Errorf("decode json: trailing content: %w", err)
 	}
 	return nil
+}
+
+// Validate checks semantic config constraints that decoding alone does not enforce.
+func (c Config) Validate() error {
+	for _, pool := range c.Pools {
+		if _, err := ResolvePoolExpectedType(pool.Type); err != nil {
+			return fmt.Errorf("pool %q type invalid: %w", pool.Name, err)
+		}
+	}
+	return nil
+}
+
+// ResolvePoolExpectedType maps a config pool type to the runtime resource type.
+func ResolvePoolExpectedType(t string) (model.ResourceType, error) {
+	switch strings.TrimSpace(t) {
+	case "", "container", "docker":
+		return model.ResourceTypeContainer, nil
+	case "vm":
+		return model.ResourceTypeVM, nil
+	case "share":
+		return model.ResourceTypeShare, nil
+	default:
+		return model.ResourceTypeUnknown, fmt.Errorf("unsupported pool type %q", t)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Geogboe/boxy/pkg/model"
 )
 
 func TestLoadFile_YAML_HappyPath(t *testing.T) {
@@ -195,5 +197,83 @@ func TestLoadFile_JSON_UnknownProviderFieldFails(t *testing.T) {
 
 	if _, err := LoadFile(p); err == nil {
 		t.Fatalf("LoadFile: expected error, got nil")
+	}
+}
+
+func TestResolvePoolExpectedType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    model.ResourceType
+		wantErr string
+	}{
+		{name: "empty defaults to container", input: "", want: model.ResourceTypeContainer},
+		{name: "container", input: "container", want: model.ResourceTypeContainer},
+		{name: "docker", input: "docker", want: model.ResourceTypeContainer},
+		{name: "vm", input: "vm", want: model.ResourceTypeVM},
+		{name: "share", input: "share", want: model.ResourceTypeShare},
+		{name: "invalid", input: "badtype", want: model.ResourceTypeUnknown, wantErr: `unsupported pool type "badtype"`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ResolvePoolExpectedType(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolvePoolExpectedType(%q) error = nil, want %q", tt.input, tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("ResolvePoolExpectedType(%q) error = %q, want %q", tt.input, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolvePoolExpectedType(%q) error = %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolvePoolExpectedType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigValidate_invalid_pool_type(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Pools: []PoolSpec{
+			{Name: "test", Type: "badtype"},
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid pool type")
+	}
+	if got, want := err.Error(), `pool "test" type invalid: unsupported pool type "badtype"`; got != want {
+		t.Fatalf("Validate() error = %q, want %q", got, want)
+	}
+}
+
+func TestConfigValidate_valid_pool_type_aliases(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Pools: []PoolSpec{
+			{Name: "default-empty"},
+			{Name: "container", Type: "container"},
+			{Name: "docker", Type: "docker"},
+			{Name: "vm", Type: "vm"},
+			{Name: "share", Type: "share"},
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- validate config pool types through shared config-level validation
- make \Configuration management

Usage:
  boxy config [flags]
  boxy config [command]

Available Commands:
  validate    Validate configuration file and exit

Flags:
  -h, --help   help for config

Global Flags:
      --log-file string    write structured logs to file instead of stderr
      --log-level string   log verbosity (debug, info, warn, error) (default "info")

Use "boxy config [command] --help" for more information about a command. and \ use the same validation path
- add regression tests for invalid pool types and accepted aliases
- include the AGENTS.md guidance update from the current worktree

Fixes #82

## Validation
- task fmt
- task test
- task lint