### PR TITLE
fix: preserve pool inventory across daemon restart

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -138,18 +139,10 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 
 	// Pools
 	donePools, failPools := ui.step("Initializing pools")
-	poolNames := make([]model.PoolName, 0, len(cfg.Pools))
-	for _, spec := range cfg.Pools {
-		p, err := poolSpecToModel(spec)
-		if err != nil {
-			failPools(err.Error())
-			return fmt.Errorf("create pool model for %q: %w", spec.Name, err)
-		}
-		if err := st.PutPool(ctx, p); err != nil {
-			failPools(err.Error())
-			return fmt.Errorf("seed pool %q: %w", spec.Name, err)
-		}
-		poolNames = append(poolNames, p.Name)
+	poolNames, err := seedConfiguredPools(ctx, st, cfg.Pools)
+	if err != nil {
+		failPools(err.Error())
+		return err
 	}
 	donePools(fmt.Sprintf("%d pool(s)", len(poolNames)))
 
@@ -172,6 +165,49 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 	printServeBanner(listenAddr, uiEnabled, len(cfg.Pools))
 
 	return g.Wait()
+}
+
+func seedConfiguredPools(ctx context.Context, st store.Store, specs []boxyconfig.PoolSpec) ([]model.PoolName, error) {
+	resources, err := st.ListResources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list resources for pool seeding: %w", err)
+	}
+
+	poolNames := make([]model.PoolName, 0, len(specs))
+	for _, spec := range specs {
+		p, err := poolSpecToModel(spec)
+		if err != nil {
+			return nil, fmt.Errorf("create pool model for %q: %w", spec.Name, err)
+		}
+
+		var fallback []model.Resource
+		existing, err := st.GetPool(ctx, p.Name)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("get existing pool %q: %w", p.Name, err)
+		}
+		if err == nil {
+			fallback = existing.Inventory.Resources
+		}
+
+		rebuilt, report, err := pool.RebuildReadyInventory(p, resources, fallback)
+		if err != nil {
+			return nil, fmt.Errorf("rebuild pool %q inventory: %w", p.Name, err)
+		}
+		for _, skipped := range report.Skipped {
+			slog.Warn(
+				"skipping persisted pool resource during startup",
+				"pool", p.Name,
+				"resource", skipped.ResourceID,
+				"reason", skipped.Reason,
+			)
+		}
+		if err := st.PutPool(ctx, rebuilt); err != nil {
+			return nil, fmt.Errorf("seed pool %q: %w", spec.Name, err)
+		}
+		poolNames = append(poolNames, rebuilt.Name)
+	}
+
+	return poolNames, nil
 }
 
 // resolveListenAddr picks the listen address with precedence:

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -8,6 +8,7 @@ import (
 
 	boxyconfig "github.com/Geogboe/boxy/internal/config"
 	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/store"
 )
 
 type fakeServePoolReconciler struct {
@@ -112,6 +113,102 @@ func TestOpenServeStore_PersistsStateAcrossReopen(t *testing.T) {
 	}
 	if got.ID != sb.ID || got.Status != model.SandboxStatusPending {
 		t.Fatalf("sandbox = %+v, want pending sandbox %q", got, sb.ID)
+	}
+}
+
+func TestSeedConfiguredPools_PreservesInventoryAndUpdatesConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	embedded := model.Resource{
+		ID:         "res-ready",
+		Type:       model.ResourceTypeVM,
+		Profile:    "win-vm",
+		OriginPool: "win-vm",
+		State:      model.ResourceStateReady,
+		Properties: map[string]any{"source": "embedded"},
+	}
+	global := embedded
+	global.Properties = map[string]any{"source": "global"}
+
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "win-vm",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 1, MaxTotal: 1},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeVM,
+			ExpectedProfile: "win-vm",
+			Resources:       []model.Resource{embedded},
+		},
+	}); err != nil {
+		t.Fatalf("put existing pool: %v", err)
+	}
+	if err := st.PutResource(ctx, global); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+
+	names, err := seedConfiguredPools(ctx, st, []boxyconfig.PoolSpec{{
+		Name: "win-vm",
+		Type: "vm",
+		Policy: boxyconfig.PoolPolicySpec{
+			Preheat: boxyconfig.PreheatPolicySpec{MinReady: 2, MaxTotal: 3},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("seedConfiguredPools: %v", err)
+	}
+	if len(names) != 1 || names[0] != "win-vm" {
+		t.Fatalf("names = %v, want [win-vm]", names)
+	}
+
+	got, err := st.GetPool(ctx, "win-vm")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if got.Policies.Preheat.MinReady != 2 || got.Policies.Preheat.MaxTotal != 3 {
+		t.Fatalf("preheat policy = %+v, want min_ready=2 max_total=3", got.Policies.Preheat)
+	}
+	if len(got.Inventory.Resources) != 1 || got.Inventory.Resources[0].ID != "res-ready" {
+		t.Fatalf("inventory resources = %+v, want res-ready", got.Inventory.Resources)
+	}
+	if got.Inventory.Resources[0].Properties["source"] != "global" {
+		t.Fatalf("inventory resource source = %v, want global", got.Inventory.Resources[0].Properties["source"])
+	}
+}
+
+func TestSeedConfiguredPools_ReconstructsReadyInventoryFromResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	resources := []model.Resource{
+		{ID: "res-ready", Type: model.ResourceTypeVM, Profile: "win-vm", OriginPool: "win-vm", State: model.ResourceStateReady},
+		{ID: "res-allocated", Type: model.ResourceTypeVM, Profile: "win-vm", OriginPool: "win-vm", State: model.ResourceStateAllocated},
+		{ID: "res-destroyed", Type: model.ResourceTypeVM, Profile: "win-vm", OriginPool: "win-vm", State: model.ResourceStateDestroyed},
+		{ID: "res-provisioning", Type: model.ResourceTypeVM, Profile: "win-vm", OriginPool: "win-vm", State: model.ResourceStateProvisioning},
+		{ID: "res-released", Type: model.ResourceTypeVM, Profile: "win-vm", OriginPool: "win-vm", State: model.ResourceStateReleased},
+		{ID: "res-wrong-profile", Type: model.ResourceTypeVM, Profile: "other", OriginPool: "win-vm", State: model.ResourceStateReady},
+		{ID: "res-wrong-type", Type: model.ResourceTypeContainer, Profile: "win-vm", OriginPool: "win-vm", State: model.ResourceStateReady},
+		{ID: "res-other-pool", Type: model.ResourceTypeVM, Profile: "win-vm", OriginPool: "other", State: model.ResourceStateReady},
+	}
+	for _, res := range resources {
+		if err := st.PutResource(ctx, res); err != nil {
+			t.Fatalf("put resource %q: %v", res.ID, err)
+		}
+	}
+
+	if _, err := seedConfiguredPools(ctx, st, []boxyconfig.PoolSpec{{Name: "win-vm", Type: "vm"}}); err != nil {
+		t.Fatalf("seedConfiguredPools: %v", err)
+	}
+
+	got, err := st.GetPool(ctx, "win-vm")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(got.Inventory.Resources) != 1 || got.Inventory.Resources[0].ID != "res-ready" {
+		t.Fatalf("inventory resources = %+v, want only res-ready", got.Inventory.Resources)
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	boxyconfig "github.com/Geogboe/boxy/internal/config"
 	"github.com/Geogboe/boxy/pkg/model"
@@ -41,16 +40,19 @@ func runStatus(ctx context.Context, opts statusOpts, cmd *cobra.Command) error {
 	// Health check
 	healthy, err := checkHealth(ctx, client, base)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  Error: cannot reach server at %s\n", addr)
-		fmt.Fprintf(os.Stderr, "  Is `boxy serve` running?\n")
+		errw := cmd.ErrOrStderr()
+		_, _ = fmt.Fprintf(errw, "  Error: cannot reach server at %s\n", addr)
+		_, _ = fmt.Fprintf(errw, "  Is `boxy serve` running?\n")
 		return err
 	}
 
-	healthStr := "healthy"
 	if !healthy {
-		healthStr = "unhealthy"
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  Error: server at %s is unhealthy\n", addr)
+		return fmt.Errorf("server at %s is unhealthy", addr)
 	}
-	fmt.Fprintf(os.Stderr, "  Server:     %s (%s)\n", base, healthStr)
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "  Server:     %s (healthy)\n", base)
 
 	// Pools
 	pools, err := fetchJSON[[]model.Pool](ctx, client, base+"/api/v1/pools")
@@ -62,14 +64,14 @@ func runStatus(ctx context.Context, opts statusOpts, cmd *cobra.Command) error {
 	for _, p := range pools {
 		totalResources += len(p.Inventory.Resources)
 	}
-	fmt.Fprintf(os.Stderr, "  Pools:      %d configured, %d resources ready\n", len(pools), totalResources)
+	_, _ = fmt.Fprintf(out, "  Pools:      %d configured, %d resources ready\n", len(pools), totalResources)
 
 	// Sandboxes
 	sandboxes, err := fetchJSON[[]model.Sandbox](ctx, client, base+"/api/v1/sandboxes")
 	if err != nil {
 		return fmt.Errorf("fetch sandboxes: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "  Sandboxes:  %d active\n", len(sandboxes))
+	_, _ = fmt.Fprintf(out, "  Sandboxes:  %d active\n", len(sandboxes))
 
 	return nil
 }

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestRunStatus_Healthy(t *testing.T) {
@@ -28,44 +29,77 @@ func TestRunStatus_Healthy(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Capture stderr
-	old := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stderr = w
-
 	addr := srv.Listener.Addr().String()
 	cmd := newStatusCommand()
+	stdout, stderr := captureCommandOutput(cmd)
 	cmd.SetArgs([]string{"--server", addr})
 	execErr := cmd.ExecuteContext(context.Background())
-
-	_ = w.Close()
-	os.Stderr = old
 
 	if execErr != nil {
 		t.Fatalf("status error: %v", execErr)
 	}
 
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("read pipe: %v", err)
-	}
-	output := buf.String()
+	output := stdout.String()
 
 	for _, want := range []string{"healthy", "1 configured", "1 resources ready", "1 active"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("expected %q in output, got: %s", want, output)
 		}
 	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
 }
 
 func TestRunStatus_ServerDown(t *testing.T) {
 	cmd := newStatusCommand()
+	stdout, stderr := captureCommandOutput(cmd)
 	cmd.SetArgs([]string{"--server", "127.0.0.1:1"}) // port 1 — nothing there
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {
 		t.Fatal("expected error when server is down")
 	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	for _, want := range []string{"cannot reach server", "boxy serve"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected stderr to contain %q, got %q", want, stderr.String())
+		}
+	}
+}
+
+func TestRunStatus_Unhealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	cmd := newStatusCommand()
+	stdout, stderr := captureCommandOutput(cmd)
+	cmd.SetArgs([]string{"--server", addr})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error when server is unhealthy")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "unhealthy") {
+		t.Fatalf("expected stderr to contain unhealthy, got %q", got)
+	}
+}
+
+func captureCommandOutput(cmd *cobra.Command) (*bytes.Buffer, *bytes.Buffer) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	return &stdout, &stderr
 }

--- a/internal/pool/inventory.go
+++ b/internal/pool/inventory.go
@@ -1,0 +1,99 @@
+package pool
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/Geogboe/boxy/pkg/model"
+)
+
+type InventoryRebuildReport struct {
+	Changed bool
+	Skipped []InventoryRebuildSkip
+}
+
+type InventoryRebuildSkip struct {
+	ResourceID model.ResourceID
+	Reason     string
+}
+
+// RebuildReadyInventory rebuilds a pool's ready inventory from persisted
+// resources while preserving old embedded inventory as a fallback for older
+// state files.
+func RebuildReadyInventory(
+	p model.Pool,
+	resources []model.Resource,
+	fallbackInventory []model.Resource,
+) (model.Pool, InventoryRebuildReport, error) {
+	report := InventoryRebuildReport{}
+	fallbackByID := make(map[model.ResourceID]model.Resource, len(fallbackInventory))
+	for _, res := range fallbackInventory {
+		if res.ID == "" {
+			continue
+		}
+		fallbackByID[res.ID] = res
+	}
+
+	globalIDs := make(map[model.ResourceID]struct{}, len(resources))
+	accepted := make(map[model.ResourceID]model.Resource)
+	for _, res := range resources {
+		if res.ID == "" {
+			continue
+		}
+		globalIDs[res.ID] = struct{}{}
+
+		_, inFallback := fallbackByID[res.ID]
+		if res.OriginPool != p.Name && (!inFallback || res.OriginPool != "") {
+			continue
+		}
+		if !matchesPoolShape(p, res) {
+			if res.OriginPool == p.Name {
+				report.Skipped = append(report.Skipped, InventoryRebuildSkip{
+					ResourceID: res.ID,
+					Reason:     "resource type/profile no longer matches pool config",
+				})
+			}
+			continue
+		}
+		if res.State != model.ResourceStateReady {
+			continue
+		}
+		accepted[res.ID] = res
+	}
+
+	for _, res := range fallbackInventory {
+		if res.ID == "" {
+			continue
+		}
+		if _, ok := accepted[res.ID]; ok {
+			continue
+		}
+		if _, hasGlobal := globalIDs[res.ID]; hasGlobal {
+			continue
+		}
+		if !matchesPoolShape(p, res) || res.State != model.ResourceStateReady {
+			continue
+		}
+		accepted[res.ID] = res
+	}
+
+	rebuilt := p
+	rebuilt.Inventory.Resources = nil
+	ids := make([]string, 0, len(accepted))
+	for id := range accepted {
+		ids = append(ids, string(id))
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		if err := rebuilt.Inventory.Add(accepted[model.ResourceID(id)]); err != nil {
+			return model.Pool{}, InventoryRebuildReport{}, fmt.Errorf("add rebuilt resource %q: %w", id, err)
+		}
+	}
+	report.Changed = !reflect.DeepEqual(p.Inventory.Resources, rebuilt.Inventory.Resources)
+	return rebuilt, report, nil
+}
+
+func matchesPoolShape(p model.Pool, res model.Resource) bool {
+	return res.Type == p.Inventory.ExpectedType && res.Profile == p.Inventory.ExpectedProfile
+}

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -93,11 +93,12 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 		now       time.Time
 	}
 	type plan struct {
-		pool        model.Pool
-		stale       []model.Resource
-		now         time.Time
-		toProvision int
-		reason      string
+		pool             model.Pool
+		stale            []model.Resource
+		now              time.Time
+		toProvision      int
+		inventoryChanged bool
+		reason           string
 	}
 
 	ctrl := policycontroller.Controller[observed, plan]{
@@ -115,6 +116,11 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 		Evaluator: policycontroller.EvaluatorFunc[observed, plan](func(ctx context.Context, obs observed) (policycontroller.Decision[plan], error) {
 			_ = ctx
 			p := obs.pool
+			rebuilt, rebuildReport, err := RebuildReadyInventory(p, obs.resources, p.Inventory.Resources)
+			if err != nil {
+				return policycontroller.Decision[plan]{}, err
+			}
+			p = rebuilt
 
 			stale, kept, err := computeStale(p, obs.now)
 			if err != nil {
@@ -140,19 +146,20 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 			toProv := computeToProvision(p, effectiveMinReady, totalCount)
 			reason := "noop"
 			should := false
-			if len(stale) > 0 || toProv > 0 {
+			if rebuildReport.Changed || len(stale) > 0 || toProv > 0 {
 				should = true
-				reason = fmt.Sprintf("stale=%d provision=%d", len(stale), toProv)
+				reason = fmt.Sprintf("inventory_rebuilt=%t stale=%d provision=%d", rebuildReport.Changed, len(stale), toProv)
 			}
 
 			return policycontroller.Decision[plan]{
 				ShouldAct: should,
 				Plan: plan{
-					pool:        p,
-					stale:       stale,
-					now:         obs.now,
-					toProvision: toProv,
-					reason:      reason,
+					pool:             p,
+					stale:            stale,
+					now:              obs.now,
+					toProvision:      toProv,
+					inventoryChanged: rebuildReport.Changed,
+					reason:           reason,
 				},
 				Reason: reason,
 			}, nil

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -223,3 +223,53 @@ func TestManager_Reconcile_IgnoresDestroyedResourcesWhenApplyingMaxTotal(t *test
 		t.Fatalf("provision count = %d, want 1", prov.n)
 	}
 }
+
+func TestManager_Reconcile_RebuildsReadyInventoryFromPersistedResources(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	ready := model.Resource{
+		ID:         "res_ready",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		Provider:   model.ProviderRef{Name: "prov_1"},
+		State:      model.ResourceStateReady,
+		CreatedAt:  time.Unix(1000, 0).UTC(),
+		UpdatedAt:  time.Unix(1000, 0).UTC(),
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put ready resource: %v", err)
+	}
+	pool := model.Pool{
+		Name: "p1",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 1, MaxTotal: 1},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updated, err := st.GetPool(ctx, "p1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(updated.Inventory.Resources) != 1 || updated.Inventory.Resources[0].ID != ready.ID {
+		t.Fatalf("inventory resources = %+v, want %q", updated.Inventory.Resources, ready.ID)
+	}
+	if prov.n != 0 {
+		t.Fatalf("provision count = %d, want 0", prov.n)
+	}
+}


### PR DESCRIPTION
## Summary
- Route successful `boxy status` output to stdout while keeping failures on stderr with non-zero errors.
- Preserve and reconstruct ready pool inventory from persisted resources during daemon startup.
- Add pool reconciliation self-healing for missing ready inventory associations.

## Test plan
- `task test:cli`
- `task lint`
- `task test`
- `go test -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out` (total coverage: 60.6%)
- Code review pass: no blocking issues
- PII/secrets scan: reviewed and approved by maintainer; WSL gitleaks findings classified safe to ship

## Related issues
Closes #114
Closes #115