### PR TITLE
feat: support desired-state pool draining

### DIFF
--- a/docs/cli-wireframe.md
+++ b/docs/cli-wireframe.md
@@ -140,6 +140,15 @@ boxy
 │
 │
 ├── debug
+│   ├── pool                                   Run daemon-backed pool maintenance
+│   │   ├── --server <addr>                      Server address (default 127.0.0.1:9090)
+│   │   ├── drain <pool>                         Drain unused ready inventory
+│   │   │   $ boxy debug pool drain win-vm
+│   │   │     drained pool win-vm
+│   │   └── fill <pool>                          Reconcile to configured min_ready
+│   │       $ boxy debug pool fill win-vm
+│   │         filled pool win-vm
+│   │
 │   └── provider                               Exercise devfactory provider
 │       ├── --data-dir <path>                    (default .devfactory/)
 │       ├── --profile container|vm|share         (default container)

--- a/internal/cli/debug.go
+++ b/internal/cli/debug.go
@@ -12,5 +12,6 @@ func newDebugCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newDebugProviderCommand())
+	cmd.AddCommand(newDebugPoolCommand())
 	return cmd
 }

--- a/internal/cli/debug_pool.go
+++ b/internal/cli/debug_pool.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/spf13/cobra"
+)
+
+func newDebugPoolCommand() *cobra.Command {
+	var server string
+	cmd := &cobra.Command{
+		Use:   "pool",
+		Short: "Run pool maintenance actions through the daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.PersistentFlags().StringVar(&server, "server", "", "server address (default 127.0.0.1:9090)")
+	serverAddr := func() string { return server }
+	cmd.AddCommand(newDebugPoolDrainCommand(serverAddr))
+	cmd.AddCommand(newDebugPoolFillCommand(serverAddr))
+	return cmd
+}
+
+func newDebugPoolDrainCommand(serverAddr func() string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "drain <pool>",
+		Short: "Drain unused ready inventory from a pool",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pool, err := postJSON[map[string]any, model.Pool](
+				cmd.Context(),
+				defaultAPIClient(),
+				apiBaseURL(serverAddr())+"/api/v1/pools/"+args[0]+"/drain",
+				map[string]any{},
+			)
+			if err != nil {
+				return fmt.Errorf("drain pool %q: %w", args[0], err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "drained pool %s\n", pool.Name)
+			return nil
+		},
+	}
+}
+
+func newDebugPoolFillCommand(serverAddr func() string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "fill <pool>",
+		Short: "Fill a pool to its configured min_ready",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pool, err := postJSON[map[string]any, model.Pool](
+				cmd.Context(),
+				defaultAPIClient(),
+				apiBaseURL(serverAddr())+"/api/v1/pools/"+args[0]+"/fill",
+				map[string]any{},
+			)
+			if err != nil {
+				return fmt.Errorf("fill pool %q: %w", args[0], err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "filled pool %s\n", pool.Name)
+			return nil
+		},
+	}
+}

--- a/internal/cli/debug_pool_test.go
+++ b/internal/cli/debug_pool_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Geogboe/boxy/pkg/model"
+)
+
+func newDebugPoolTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/pools/{name}/drain", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		if name == "missing" {
+			http.Error(w, `{"error":"pool not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := printJSONTo(w, model.Pool{Name: model.PoolName(name), Drain: model.PoolDrainState{Operator: true}}); err != nil {
+			t.Fatalf("encode pool: %v", err)
+		}
+	})
+	mux.HandleFunc("POST /api/v1/pools/{name}/fill", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		if name == "config-drained" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = fmt.Fprint(w, `{"error":"pool \"config-drained\" is configured drained; edit config before filling it"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := printJSONTo(w, model.Pool{Name: model.PoolName(name)}); err != nil {
+			t.Fatalf("encode pool: %v", err)
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestDebugPoolDrain_success(t *testing.T) {
+	srv := newDebugPoolTestServer(t)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"debug", "pool", "--server", srv.URL, "drain", "web"})
+
+	output, err := captureSandboxStdout(t, func() error {
+		return cmd.ExecuteContext(context.Background())
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(output, "drained pool web") {
+		t.Fatalf("output = %q, want drain success", output)
+	}
+}
+
+func TestDebugPoolFill_success(t *testing.T) {
+	srv := newDebugPoolTestServer(t)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"debug", "pool", "--server", srv.URL, "fill", "web"})
+
+	output, err := captureSandboxStdout(t, func() error {
+		return cmd.ExecuteContext(context.Background())
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(output, "filled pool web") {
+		t.Fatalf("output = %q, want fill success", output)
+	}
+}
+
+func TestDebugPoolDrain_error(t *testing.T) {
+	srv := newDebugPoolTestServer(t)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"debug", "pool", "--server", srv.URL, "drain", "missing"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("execute error = nil, want missing pool")
+	}
+	if !strings.Contains(err.Error(), "pool not found") {
+		t.Fatalf("error = %v, want pool not found", err)
+	}
+}
+
+func TestDebugPoolFill_configDeclaredDrain(t *testing.T) {
+	srv := newDebugPoolTestServer(t)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"debug", "pool", "--server", srv.URL, "fill", "config-drained"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("execute error = nil, want config drain")
+	}
+	if !strings.Contains(err.Error(), "configured drained") {
+		t.Fatalf("error = %v, want configured drained message", err)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -152,7 +152,7 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 	// Resolve UI enabled: flag > config > default (true)
 	uiEnabled := resolveUIEnabled(opts, cmd, cfg)
 
-	srv := server.New(st, sandboxMgr, listenAddr, uiEnabled)
+	srv := server.New(st, sandboxMgr, poolMgr, listenAddr, uiEnabled)
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -187,6 +187,7 @@ func seedConfiguredPools(ctx context.Context, st store.Store, specs []boxyconfig
 		}
 		if err == nil {
 			fallback = existing.Inventory.Resources
+			p.Drain.Operator = existing.Drain.Operator
 		}
 
 		rebuilt, report, err := pool.RebuildReadyInventory(p, resources, fallback)
@@ -364,6 +365,9 @@ func poolSpecToModel(spec boxyconfig.PoolSpec) (model.Pool, error) {
 			Recycle: model.RecyclePolicy{
 				MaxAge: policy.Recycle.MaxAge,
 			},
+		},
+		Drain: model.PoolDrainState{
+			ConfigDeclared: policy.Preheat.ConfiguresDrain(),
 		},
 		Inventory: model.ResourceCollection{
 			ExpectedType:    expectedType,

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -129,6 +130,7 @@ func TestSeedConfiguredPools_PreservesInventoryAndUpdatesConfig(t *testing.T) {
 		State:      model.ResourceStateReady,
 		Properties: map[string]any{"source": "embedded"},
 	}
+
 	global := embedded
 	global.Properties = map[string]any{"source": "global"}
 
@@ -178,6 +180,35 @@ func TestSeedConfiguredPools_PreservesInventoryAndUpdatesConfig(t *testing.T) {
 	}
 }
 
+func TestSeedConfiguredPools_PreservesOperatorDrainOverride(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "web",
+		Drain: model.PoolDrainState{Operator: true},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "web",
+		},
+	}); err != nil {
+		t.Fatalf("put existing pool: %v", err)
+	}
+
+	if _, err := seedConfiguredPools(ctx, st, []boxyconfig.PoolSpec{{Name: "web", Type: "container"}}); err != nil {
+		t.Fatalf("seedConfiguredPools: %v", err)
+	}
+
+	got, err := st.GetPool(ctx, "web")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !got.Drain.Operator {
+		t.Fatalf("operator drain override = false, want true")
+	}
+}
+
 func TestSeedConfiguredPools_ReconstructsReadyInventoryFromResources(t *testing.T) {
 	t.Parallel()
 
@@ -221,5 +252,64 @@ func TestPoolSpecToModel_invalid_pool_type(t *testing.T) {
 	}
 	if got, want := err.Error(), `pool "test" type invalid: unsupported pool type "badtype"`; got != want {
 		t.Fatalf("poolSpecToModel() error = %q, want %q", got, want)
+	}
+}
+
+func TestPoolSpecToModel_DrainExplicitnessFromConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "boxy.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+providers: []
+pools:
+  - name: lazy
+    type: container
+    policy:
+      preheat:
+        min_ready: 0
+  - name: drained
+    type: container
+    policy:
+      preheat:
+        min_ready: 0
+        max_total: 0
+  - name: capped
+    type: container
+    policy:
+      preheat:
+        min_ready: 0
+        max_total: 2
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	lazy, err := poolSpecToModel(cfg.Pools[0])
+	if err != nil {
+		t.Fatalf("poolSpecToModel(lazy): %v", err)
+	}
+	if lazy.Policies.Preheat.MaxTotal != 0 || lazy.EffectivelyDrained() {
+		t.Fatalf("lazy pool max_total=%d drained=%t, want unbounded and not drained", lazy.Policies.Preheat.MaxTotal, lazy.EffectivelyDrained())
+	}
+
+	drained, err := poolSpecToModel(cfg.Pools[1])
+	if err != nil {
+		t.Fatalf("poolSpecToModel(drained): %v", err)
+	}
+	if !drained.Drain.ConfigDeclared || !drained.EffectivelyDrained() {
+		t.Fatalf("drained pool drain state = %+v, want config-declared drain", drained.Drain)
+	}
+
+	capped, err := poolSpecToModel(cfg.Pools[2])
+	if err != nil {
+		t.Fatalf("poolSpecToModel(capped): %v", err)
+	}
+	if capped.Policies.Preheat.MaxTotal != 2 || capped.EffectivelyDrained() {
+		t.Fatalf("capped pool max_total=%d drained=%t, want finite cap and not drained", capped.Policies.Preheat.MaxTotal, capped.EffectivelyDrained())
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,13 @@ func (c Config) Validate() error {
 		if _, err := ResolvePoolExpectedType(pool.Type); err != nil {
 			return fmt.Errorf("pool %q type invalid: %w", pool.Name, err)
 		}
+		if pool.PolicySet() && pool.PoliciesSet() {
+			return fmt.Errorf("pool %q sets both policy and policies; use only one", pool.Name)
+		}
+		policy := pool.EffectivePolicy()
+		if policy.Preheat.ConfiguresDrain() && policy.Preheat.MinReady > 0 {
+			return fmt.Errorf("pool %q preheat max_total: 0 conflicts with min_ready: %d", pool.Name, policy.Preheat.MinReady)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -277,3 +277,126 @@ func TestConfigValidate_valid_pool_type_aliases(t *testing.T) {
 		t.Fatalf("Validate() error = %v", err)
 	}
 }
+
+func TestPoolSpec_PreheatExplicitness(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "boxy.yaml")
+	if err := os.WriteFile(path, []byte(`
+providers: []
+pools:
+  - name: omitted-max
+    type: container
+    policy:
+      preheat:
+        min_ready: 0
+  - name: explicit-drain
+    type: container
+    policy:
+      preheat:
+        min_ready: 0
+        max_total: 0
+  - name: alias-drain
+    type: container
+    policies:
+      preheat:
+        max_total: 0
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	omitted := cfg.Pools[0].EffectivePolicy().Preheat
+	if omitted.MaxTotal != 0 || omitted.MaxTotalSet() {
+		t.Fatalf("omitted max_total = (%d, set=%t), want zero and unset", omitted.MaxTotal, omitted.MaxTotalSet())
+	}
+	if omitted.ConfiguresDrain() {
+		t.Fatal("omitted max_total configured drain")
+	}
+
+	explicit := cfg.Pools[1].EffectivePolicy().Preheat
+	if explicit.MaxTotal != 0 || !explicit.MaxTotalSet() || !explicit.ConfiguresDrain() {
+		t.Fatalf("explicit max_total = (%d, set=%t, drain=%t), want explicit drain", explicit.MaxTotal, explicit.MaxTotalSet(), explicit.ConfiguresDrain())
+	}
+
+	alias := cfg.Pools[2]
+	if !alias.PoliciesSet() || alias.PolicySet() {
+		t.Fatalf("alias flags policy=%t policies=%t, want only policies", alias.PolicySet(), alias.PoliciesSet())
+	}
+	if !alias.EffectivePolicy().Preheat.ConfiguresDrain() {
+		t.Fatal("policies alias explicit max_total: 0 did not configure drain")
+	}
+}
+
+func TestConfigValidate_rejectsPolicyAliasesTogether(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "boxy.yaml")
+	if err := os.WriteFile(path, []byte(`
+providers: []
+pools:
+  - name: web
+    type: container
+    policy:
+      preheat:
+        min_ready: 0
+    policies:
+      preheat:
+        max_total: 0
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want policy alias conflict")
+	}
+	if got, want := err.Error(), `pool "web" sets both policy and policies; use only one`; got != want {
+		t.Fatalf("Validate() error = %q, want %q", got, want)
+	}
+}
+
+func TestConfigValidate_rejectsDrainWithPositiveMinReady(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "boxy.yaml")
+	if err := os.WriteFile(path, []byte(`
+providers: []
+pools:
+  - name: web
+    type: container
+    policy:
+      preheat:
+        min_ready: 1
+        max_total: 0
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want drain/min_ready conflict")
+	}
+	if got, want := err.Error(), `pool "web" preheat max_total: 0 conflicts with min_ready: 1`; got != want {
+		t.Fatalf("Validate() error = %q, want %q", got, want)
+	}
+}

--- a/internal/config/pool_spec.go
+++ b/internal/config/pool_spec.go
@@ -1,5 +1,12 @@
 package config
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
 // PoolSpec is the user-facing YAML/JSON representation of a poolmanager.
 //
 // This is intentionally decoupled from internal/model.Pool so we can evolve the
@@ -24,13 +31,24 @@ type PoolSpec struct {
 
 	// Policies is accepted as an alias for Policy.
 	Policies PoolPolicySpec `json:"policies,omitempty" yaml:"policies,omitempty"`
+
+	policySet   bool
+	policiesSet bool
 }
 
 func (p PoolSpec) EffectivePolicy() PoolPolicySpec {
-	if p.Policies.Preheat.MinReady != 0 || p.Policies.Preheat.MaxTotal != 0 || p.Policies.Recycle.MaxAge != "" {
+	if p.PoliciesSet() {
 		return p.Policies
 	}
 	return p.Policy
+}
+
+func (p PoolSpec) PolicySet() bool {
+	return p.policySet || p.Policy.hasValues()
+}
+
+func (p PoolSpec) PoliciesSet() bool {
+	return p.policiesSet || p.Policies.hasValues()
 }
 
 type PoolPolicySpec struct {
@@ -38,11 +56,246 @@ type PoolPolicySpec struct {
 	Recycle RecyclePolicySpec `json:"recycle,omitempty" yaml:"recycle,omitempty"`
 }
 
+func (p PoolPolicySpec) hasValues() bool {
+	return p.Preheat.MinReady != 0 ||
+		p.Preheat.MaxTotal != 0 ||
+		p.Preheat.MinReadySet() ||
+		p.Preheat.MaxTotalSet() ||
+		p.Recycle.MaxAge != ""
+}
+
 type PreheatPolicySpec struct {
 	MinReady int `json:"min_ready,omitempty" yaml:"min_ready,omitempty"`
 	MaxTotal int `json:"max_total,omitempty" yaml:"max_total,omitempty"`
+
+	minReadySet bool
+	maxTotalSet bool
+}
+
+func (p PreheatPolicySpec) MinReadySet() bool {
+	return p.minReadySet
+}
+
+func (p PreheatPolicySpec) MaxTotalSet() bool {
+	return p.maxTotalSet
+}
+
+func (p PreheatPolicySpec) ConfiguresDrain() bool {
+	return p.maxTotalSet && p.MaxTotal == 0
 }
 
 type RecyclePolicySpec struct {
 	MaxAge string `json:"max_age,omitempty" yaml:"max_age,omitempty"`
+}
+
+func (p *PoolPolicySpec) UnmarshalJSON(b []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return err
+	}
+	for key, raw := range fields {
+		switch key {
+		case "preheat":
+			if err := json.Unmarshal(raw, &p.Preheat); err != nil {
+				return fmt.Errorf("preheat: %w", err)
+			}
+		case "recycle":
+			if err := json.Unmarshal(raw, &p.Recycle); err != nil {
+				return fmt.Errorf("recycle: %w", err)
+			}
+		default:
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+	return nil
+}
+
+func (p *PoolPolicySpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("pool policy must be a mapping")
+	}
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch key {
+		case "preheat":
+			if err := val.Decode(&p.Preheat); err != nil {
+				return fmt.Errorf("preheat: %w", err)
+			}
+		case "recycle":
+			if err := val.Decode(&p.Recycle); err != nil {
+				return fmt.Errorf("recycle: %w", err)
+			}
+		default:
+			return fmt.Errorf("field %s not found in type config.PoolPolicySpec", key)
+		}
+	}
+	return nil
+}
+
+func (p *RecyclePolicySpec) UnmarshalJSON(b []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return err
+	}
+	for key, raw := range fields {
+		switch key {
+		case "max_age":
+			if err := json.Unmarshal(raw, &p.MaxAge); err != nil {
+				return fmt.Errorf("max_age: %w", err)
+			}
+		default:
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+	return nil
+}
+
+func (p *RecyclePolicySpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("recycle policy must be a mapping")
+	}
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch key {
+		case "max_age":
+			if err := val.Decode(&p.MaxAge); err != nil {
+				return fmt.Errorf("max_age: %w", err)
+			}
+		default:
+			return fmt.Errorf("field %s not found in type config.RecyclePolicySpec", key)
+		}
+	}
+	return nil
+}
+
+func (p *PoolSpec) UnmarshalJSON(b []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return err
+	}
+	for key, raw := range fields {
+		switch key {
+		case "name":
+			if err := json.Unmarshal(raw, &p.Name); err != nil {
+				return fmt.Errorf("name: %w", err)
+			}
+		case "type":
+			if err := json.Unmarshal(raw, &p.Type); err != nil {
+				return fmt.Errorf("type: %w", err)
+			}
+		case "provider":
+			if err := json.Unmarshal(raw, &p.Provider); err != nil {
+				return fmt.Errorf("provider: %w", err)
+			}
+		case "config":
+			if err := json.Unmarshal(raw, &p.Config); err != nil {
+				return fmt.Errorf("config: %w", err)
+			}
+		case "policy":
+			p.policySet = true
+			if err := json.Unmarshal(raw, &p.Policy); err != nil {
+				return fmt.Errorf("policy: %w", err)
+			}
+		case "policies":
+			p.policiesSet = true
+			if err := json.Unmarshal(raw, &p.Policies); err != nil {
+				return fmt.Errorf("policies: %w", err)
+			}
+		default:
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+	return nil
+}
+
+func (p *PoolSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("pool spec must be a mapping")
+	}
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch key {
+		case "name":
+			if err := val.Decode(&p.Name); err != nil {
+				return fmt.Errorf("name: %w", err)
+			}
+		case "type":
+			if err := val.Decode(&p.Type); err != nil {
+				return fmt.Errorf("type: %w", err)
+			}
+		case "provider":
+			if err := val.Decode(&p.Provider); err != nil {
+				return fmt.Errorf("provider: %w", err)
+			}
+		case "config":
+			if err := val.Decode(&p.Config); err != nil {
+				return fmt.Errorf("config: %w", err)
+			}
+		case "policy":
+			p.policySet = true
+			if err := val.Decode(&p.Policy); err != nil {
+				return fmt.Errorf("policy: %w", err)
+			}
+		case "policies":
+			p.policiesSet = true
+			if err := val.Decode(&p.Policies); err != nil {
+				return fmt.Errorf("policies: %w", err)
+			}
+		default:
+			return fmt.Errorf("field %s not found in type config.PoolSpec", key)
+		}
+	}
+	return nil
+}
+
+func (p *PreheatPolicySpec) UnmarshalJSON(b []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return err
+	}
+	for key, raw := range fields {
+		switch key {
+		case "min_ready":
+			p.minReadySet = true
+			if err := json.Unmarshal(raw, &p.MinReady); err != nil {
+				return fmt.Errorf("min_ready: %w", err)
+			}
+		case "max_total":
+			p.maxTotalSet = true
+			if err := json.Unmarshal(raw, &p.MaxTotal); err != nil {
+				return fmt.Errorf("max_total: %w", err)
+			}
+		default:
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+	return nil
+}
+
+func (p *PreheatPolicySpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("preheat policy must be a mapping")
+	}
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch key {
+		case "min_ready":
+			p.minReadySet = true
+			if err := val.Decode(&p.MinReady); err != nil {
+				return fmt.Errorf("min_ready: %w", err)
+			}
+		case "max_total":
+			p.maxTotalSet = true
+			if err := val.Decode(&p.MaxTotal); err != nil {
+				return fmt.Errorf("max_total: %w", err)
+			}
+		default:
+			return fmt.Errorf("field %s not found in type config.PreheatPolicySpec", key)
+		}
+	}
+	return nil
 }

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/Geogboe/boxy/pkg/model"
@@ -38,11 +39,30 @@ func (e *MaxTotalReachedError) Error() string {
 	)
 }
 
+type DrainedPoolError struct {
+	PoolName       model.PoolName
+	RequestedReady int
+}
+
+func (e *DrainedPoolError) Error() string {
+	return fmt.Sprintf("pool %q is drained; cannot satisfy requested ready count %d", e.PoolName, e.RequestedReady)
+}
+
+type ConfigDeclaredDrainError struct {
+	PoolName model.PoolName
+}
+
+func (e *ConfigDeclaredDrainError) Error() string {
+	return fmt.Sprintf("pool %q is configured drained; edit config before filling it", e.PoolName)
+}
+
 // Manager reconciles a pool's inventory against its policies.
 type Manager struct {
 	store       store.Store
 	provisioner Provisioner
 	clock       Clock
+	locksMu     sync.Mutex
+	poolLocks   map[model.PoolName]*sync.Mutex
 }
 
 func New(s store.Store, p Provisioner) *Manager {
@@ -50,6 +70,7 @@ func New(s store.Store, p Provisioner) *Manager {
 		store:       s,
 		provisioner: p,
 		clock:       realClock{},
+		poolLocks:   make(map[model.PoolName]*sync.Mutex),
 	}
 }
 
@@ -61,7 +82,12 @@ func (m *Manager) SetClock(c Clock) {
 
 // Reconcile performs one reconciliation pass for the pool.
 func (m *Manager) Reconcile(ctx context.Context, poolName model.PoolName) error {
-	return m.reconcile(ctx, poolName, 0, false)
+	if m == nil {
+		return fmt.Errorf("pool manager is nil")
+	}
+	unlock := m.lockPool(poolName)
+	defer unlock()
+	return m.reconcileLocked(ctx, poolName, 0, false)
 }
 
 // EnsureReady ensures the pool has at least minReady resources available,
@@ -70,10 +96,102 @@ func (m *Manager) EnsureReady(ctx context.Context, poolName model.PoolName, minR
 	if minReady <= 0 {
 		return nil
 	}
-	return m.reconcile(ctx, poolName, minReady, true)
+	if m == nil {
+		return fmt.Errorf("pool manager is nil")
+	}
+	unlock := m.lockPool(poolName)
+	defer unlock()
+	return m.reconcileLocked(ctx, poolName, minReady, true)
 }
 
-func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minReadyOverride int, requireMinReady bool) error {
+// Drain persists an operator drain override and immediately destroys unused ready inventory.
+func (m *Manager) Drain(ctx context.Context, poolName model.PoolName) (model.Pool, error) {
+	if m == nil {
+		return model.Pool{}, fmt.Errorf("pool manager is nil")
+	}
+	if m.store == nil {
+		return model.Pool{}, fmt.Errorf("store is nil")
+	}
+	if m.provisioner == nil {
+		return model.Pool{}, fmt.Errorf("provisioner is nil")
+	}
+	if poolName == "" {
+		return model.Pool{}, fmt.Errorf("pool name is required")
+	}
+	unlock := m.lockPool(poolName)
+	defer unlock()
+
+	p, err := m.store.GetPool(ctx, poolName)
+	if err != nil {
+		return model.Pool{}, fmt.Errorf("get pool: %w", err)
+	}
+	p.Drain.Operator = true
+	if err := m.store.PutPool(ctx, p); err != nil {
+		return model.Pool{}, fmt.Errorf("put pool drain override: %w", err)
+	}
+	if err := m.reconcileLocked(ctx, poolName, 0, false); err != nil {
+		return model.Pool{}, err
+	}
+	return m.store.GetPool(ctx, poolName)
+}
+
+// Fill clears an operator drain override and immediately reconciles configured capacity.
+func (m *Manager) Fill(ctx context.Context, poolName model.PoolName) (model.Pool, error) {
+	if m == nil {
+		return model.Pool{}, fmt.Errorf("pool manager is nil")
+	}
+	if m.store == nil {
+		return model.Pool{}, fmt.Errorf("store is nil")
+	}
+	if m.provisioner == nil {
+		return model.Pool{}, fmt.Errorf("provisioner is nil")
+	}
+	if poolName == "" {
+		return model.Pool{}, fmt.Errorf("pool name is required")
+	}
+	unlock := m.lockPool(poolName)
+	defer unlock()
+
+	p, err := m.store.GetPool(ctx, poolName)
+	if err != nil {
+		return model.Pool{}, fmt.Errorf("get pool: %w", err)
+	}
+	p.Drain.Operator = false
+	if err := m.store.PutPool(ctx, p); err != nil {
+		return model.Pool{}, fmt.Errorf("clear pool drain override: %w", err)
+	}
+	if p.Drain.ConfigDeclared {
+		if err := m.reconcileLocked(ctx, poolName, 0, false); err != nil {
+			return model.Pool{}, err
+		}
+		updated, err := m.store.GetPool(ctx, poolName)
+		if err != nil {
+			return model.Pool{}, fmt.Errorf("get pool after config-declared drain fill: %w", err)
+		}
+		return updated, &ConfigDeclaredDrainError{PoolName: poolName}
+	}
+	if err := m.reconcileLocked(ctx, poolName, 0, false); err != nil {
+		return model.Pool{}, err
+	}
+	return m.store.GetPool(ctx, poolName)
+}
+
+func (m *Manager) lockPool(poolName model.PoolName) func() {
+	m.locksMu.Lock()
+	if m.poolLocks == nil {
+		m.poolLocks = make(map[model.PoolName]*sync.Mutex)
+	}
+	lock := m.poolLocks[poolName]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		m.poolLocks[poolName] = lock
+	}
+	m.locksMu.Unlock()
+	lock.Lock()
+	return lock.Unlock
+}
+
+func (m *Manager) reconcileLocked(ctx context.Context, poolName model.PoolName, minReadyOverride int, requireMinReady bool) error {
 	if m == nil {
 		return fmt.Errorf("pool manager is nil")
 	}
@@ -95,6 +213,8 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 	type plan struct {
 		pool             model.Pool
 		stale            []model.Resource
+		drainResources   []model.Resource
+		drain            bool
 		now              time.Time
 		toProvision      int
 		inventoryChanged bool
@@ -121,6 +241,29 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 				return policycontroller.Decision[plan]{}, err
 			}
 			p = rebuilt
+
+			if p.EffectivelyDrained() {
+				if requireMinReady {
+					return policycontroller.Decision[plan]{}, &DrainedPoolError{
+						PoolName:       p.Name,
+						RequestedReady: minReadyOverride,
+					}
+				}
+				toDrain := append([]model.Resource(nil), p.Inventory.Resources...)
+				reason := fmt.Sprintf("drain inventory_rebuilt=%t ready=%d", rebuildReport.Changed, len(toDrain))
+				return policycontroller.Decision[plan]{
+					ShouldAct: rebuildReport.Changed || len(toDrain) > 0,
+					Plan: plan{
+						pool:             p,
+						drainResources:   toDrain,
+						drain:            true,
+						now:              obs.now,
+						inventoryChanged: rebuildReport.Changed,
+						reason:           reason,
+					},
+					Reason: reason,
+				}, nil
+			}
 
 			stale, kept, err := computeStale(p, obs.now)
 			if err != nil {
@@ -166,6 +309,9 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 		}),
 		Actuator: policycontroller.ActuatorFunc[plan](func(ctx context.Context, pl plan) error {
 			p := pl.pool
+			if pl.drain {
+				return m.applyDrain(ctx, p, pl.drainResources)
+			}
 
 			for _, res := range pl.stale {
 				if err := m.provisioner.Destroy(ctx, p, res); err != nil {
@@ -207,8 +353,54 @@ func (m *Manager) reconcile(ctx context.Context, poolName model.PoolName, minRea
 		if errors.As(err, &capErr) {
 			return capErr
 		}
+		var drainedErr *DrainedPoolError
+		if errors.As(err, &drainedErr) {
+			return drainedErr
+		}
 	}
 	return err
+}
+
+func (m *Manager) applyDrain(ctx context.Context, p model.Pool, resources []model.Resource) error {
+	if len(resources) == 0 {
+		p.Inventory.Resources = nil
+		if err := m.store.PutPool(ctx, p); err != nil {
+			return fmt.Errorf("put drained pool: %w", err)
+		}
+		return nil
+	}
+
+	for _, res := range resources {
+		if err := m.provisioner.Destroy(ctx, p, res); err != nil {
+			return fmt.Errorf("destroy drained resource %q in pool %q: %w", res.ID, p.Name, err)
+		}
+		res.State = model.ResourceStateDestroyed
+		if err := m.store.PutResource(ctx, res); err != nil {
+			return fmt.Errorf("mark drained resource %q destroyed: %w", res.ID, err)
+		}
+		p.Inventory.Resources = removeInventoryResource(p.Inventory.Resources, res.ID)
+		if err := m.store.PutPool(ctx, p); err != nil {
+			return fmt.Errorf("put drained pool: %w", err)
+		}
+		if err := m.store.DeleteResource(ctx, res.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("delete drained resource %q: %w", res.ID, err)
+		}
+	}
+	return nil
+}
+
+func removeInventoryResource(resources []model.Resource, id model.ResourceID) []model.Resource {
+	out := resources[:0]
+	for _, res := range resources {
+		if res.ID == id {
+			continue
+		}
+		out = append(out, res)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func computeStale(p model.Pool, now time.Time) (stale []model.Resource, kept []model.Resource, _ error) {

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,7 +11,9 @@ import (
 )
 
 type fakeProvisioner struct {
-	n int
+	n          int
+	destroyed  []model.ResourceID
+	destroyErr error
 }
 
 func (p *fakeProvisioner) Provision(ctx context.Context, pool model.Pool) (model.Resource, error) {
@@ -29,13 +32,27 @@ func (p *fakeProvisioner) Provision(ctx context.Context, pool model.Pool) (model
 func (p *fakeProvisioner) Destroy(ctx context.Context, pool model.Pool, res model.Resource) error {
 	_ = ctx
 	_ = pool
-	_ = res
+	p.destroyed = append(p.destroyed, res.ID)
+	if p.destroyErr != nil {
+		return p.destroyErr
+	}
 	return nil
 }
 
 type fixedClock struct{ t time.Time }
 
 func (c fixedClock) Now() time.Time { return c.t }
+
+type deleteFailStore struct {
+	store.Store
+	err error
+}
+
+func (s *deleteFailStore) DeleteResource(ctx context.Context, id model.ResourceID) error {
+	_ = ctx
+	_ = id
+	return s.err
+}
 
 func TestManager_Reconcile_PrefillMinReady(t *testing.T) {
 	st := store.NewMemoryStore()
@@ -271,5 +288,327 @@ func TestManager_Reconcile_RebuildsReadyInventoryFromPersistedResources(t *testi
 	}
 	if prov.n != 0 {
 		t.Fatalf("provision count = %d, want 0", prov.n)
+	}
+}
+
+func TestManager_Reconcile_DrainsReadyInventory(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	ready := model.Resource{
+		ID:         "res_ready",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		State:      model.ResourceStateReady,
+	}
+	allocated := model.Resource{
+		ID:         "res_allocated",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		State:      model.ResourceStateAllocated,
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put ready resource: %v", err)
+	}
+	if err := st.PutResource(ctx, allocated); err != nil {
+		t.Fatalf("put allocated resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "p1",
+		Drain: model.PoolDrainState{ConfigDeclared: true},
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 0, MaxTotal: 0},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if len(prov.destroyed) != 1 || prov.destroyed[0] != ready.ID {
+		t.Fatalf("destroyed = %v, want [%s]", prov.destroyed, ready.ID)
+	}
+	if prov.n != 0 {
+		t.Fatalf("provision count = %d, want 0", prov.n)
+	}
+	if _, err := st.GetResource(ctx, ready.ID); err != store.ErrNotFound {
+		t.Fatalf("ready resource after drain err = %v, want ErrNotFound", err)
+	}
+	if _, err := st.GetResource(ctx, allocated.ID); err != nil {
+		t.Fatalf("allocated resource should remain: %v", err)
+	}
+	updated, err := st.GetPool(ctx, "p1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(updated.Inventory.Resources) != 0 {
+		t.Fatalf("inventory len = %d, want 0", len(updated.Inventory.Resources))
+	}
+}
+
+func TestManager_Reconcile_DrainProviderFailureKeepsStateForRetry(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	ready := model.Resource{
+		ID:         "res_ready",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		State:      model.ResourceStateReady,
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put ready resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "p1",
+		Drain: model.PoolDrainState{Operator: true},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{destroyErr: errors.New("provider unavailable")}
+	mgr := New(st, prov)
+	err := mgr.Reconcile(ctx, "p1")
+	if err == nil {
+		t.Fatal("reconcile error = nil, want provider failure")
+	}
+	if _, getErr := st.GetResource(ctx, ready.ID); getErr != nil {
+		t.Fatalf("ready resource should remain for retry: %v", getErr)
+	}
+	updated, getErr := st.GetPool(ctx, "p1")
+	if getErr != nil {
+		t.Fatalf("get pool: %v", getErr)
+	}
+	if len(updated.Inventory.Resources) != 1 || updated.Inventory.Resources[0].ID != ready.ID {
+		t.Fatalf("inventory = %+v, want failed resource visible", updated.Inventory.Resources)
+	}
+}
+
+func TestManager_Reconcile_DrainDeleteFailureMarksDestroyedForRetry(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	ready := model.Resource{
+		ID:         "res_ready",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		State:      model.ResourceStateReady,
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put ready resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "p1",
+		Drain: model.PoolDrainState{Operator: true},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	deleteErr := errors.New("delete failed")
+	failingStore := &deleteFailStore{Store: st, err: deleteErr}
+	prov := &fakeProvisioner{}
+	mgr := New(failingStore, prov)
+	err := mgr.Reconcile(ctx, "p1")
+	if err == nil {
+		t.Fatal("reconcile error = nil, want delete failure")
+	}
+
+	stored, getErr := st.GetResource(ctx, ready.ID)
+	if getErr != nil {
+		t.Fatalf("get ready resource after delete failure: %v", getErr)
+	}
+	if stored.State != model.ResourceStateDestroyed {
+		t.Fatalf("resource state = %q, want %q", stored.State, model.ResourceStateDestroyed)
+	}
+	updated, getErr := st.GetPool(ctx, "p1")
+	if getErr != nil {
+		t.Fatalf("get pool: %v", getErr)
+	}
+	if len(updated.Inventory.Resources) != 0 {
+		t.Fatalf("inventory len = %d, want 0", len(updated.Inventory.Resources))
+	}
+
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(prov.destroyed) != 1 {
+		t.Fatalf("destroy calls = %v, want no retry after destroyed marker", prov.destroyed)
+	}
+}
+
+func TestManager_Reconcile_DrainLegacyEmbeddedInventory(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	legacy := model.Resource{
+		ID:      "res_legacy",
+		Type:    model.ResourceTypeContainer,
+		Profile: model.ResourceProfileDefault,
+		State:   model.ResourceStateReady,
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "p1",
+		Drain: model.PoolDrainState{Operator: true},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+			Resources:       []model.Resource{legacy},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(prov.destroyed) != 1 || prov.destroyed[0] != legacy.ID {
+		t.Fatalf("destroyed = %v, want legacy resource", prov.destroyed)
+	}
+	updated, err := st.GetPool(ctx, "p1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(updated.Inventory.Resources) != 0 {
+		t.Fatalf("inventory len = %d, want 0", len(updated.Inventory.Resources))
+	}
+}
+
+func TestManager_EnsureReady_FailsWhenPoolDrained(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "p1",
+		Drain: model.PoolDrainState{Operator: true},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+	err := mgr.EnsureReady(ctx, "p1", 1)
+	if err == nil {
+		t.Fatal("EnsureReady error = nil, want drained pool error")
+	}
+	if got, want := err.Error(), `pool "p1" is drained; cannot satisfy requested ready count 1`; got != want {
+		t.Fatalf("EnsureReady error = %q, want %q", got, want)
+	}
+	if prov.n != 0 {
+		t.Fatalf("provision count = %d, want 0", prov.n)
+	}
+}
+
+func TestManager_Fill_ConfigDeclaredDrainStillDrainsInventory(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	ready := model.Resource{
+		ID:         "res_ready",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "p1",
+		State:      model.ResourceStateReady,
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put ready resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "p1",
+		Drain: model.PoolDrainState{
+			ConfigDeclared: true,
+			Operator:       true,
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+	filled, err := mgr.Fill(ctx, "p1")
+	if err == nil {
+		t.Fatal("Fill error = nil, want config-declared drain error")
+	}
+	var configErr *ConfigDeclaredDrainError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("Fill error = %T %[1]v, want ConfigDeclaredDrainError", err)
+	}
+	if len(prov.destroyed) != 1 || prov.destroyed[0] != ready.ID {
+		t.Fatalf("destroyed = %v, want [%s]", prov.destroyed, ready.ID)
+	}
+	if filled.Drain.Operator {
+		t.Fatal("returned operator drain = true, want cleared")
+	}
+	if len(filled.Inventory.Resources) != 0 {
+		t.Fatalf("returned inventory len = %d, want 0", len(filled.Inventory.Resources))
+	}
+	if _, err := st.GetResource(ctx, ready.ID); err != store.ErrNotFound {
+		t.Fatalf("ready resource after fill err = %v, want ErrNotFound", err)
+	}
+	updated, err := st.GetPool(ctx, "p1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if updated.Drain.Operator {
+		t.Fatal("operator drain = true, want cleared")
+	}
+	if !updated.Drain.ConfigDeclared || !updated.EffectivelyDrained() {
+		t.Fatalf("drain state = %+v, want config-declared effective drain", updated.Drain)
+	}
+	if len(updated.Inventory.Resources) != 0 {
+		t.Fatalf("inventory len = %d, want 0", len(updated.Inventory.Resources))
+	}
+}
+
+func TestManager_Reconcile_DrainEmptyInventoryIsIdempotent(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	if err := st.PutPool(ctx, model.Pool{
+		Name:  "p1",
+		Drain: model.PoolDrainState{Operator: true},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(prov.destroyed) != 0 || prov.n != 0 {
+		t.Fatalf("destroyed=%v provisioned=%d, want no operations", prov.destroyed, prov.n)
 	}
 }

--- a/internal/server/api_pools.go
+++ b/internal/server/api_pools.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/Geogboe/boxy/internal/pool"
 	"github.com/Geogboe/boxy/pkg/httpjson"
 	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/store"
@@ -13,6 +14,8 @@ import (
 func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/pools", s.handleListPools)
 	mux.HandleFunc("GET /api/v1/pools/{name}", s.handleGetPool)
+	mux.HandleFunc("POST /api/v1/pools/{name}/drain", s.handleDrainPool)
+	mux.HandleFunc("POST /api/v1/pools/{name}/fill", s.handleFillPool)
 	mux.HandleFunc("GET /api/v1/resources", s.handleListResources)
 	mux.HandleFunc("GET /api/v1/resources/{id}", s.handleGetResource)
 	mux.HandleFunc("GET /api/v1/sandboxes", s.handleListSandboxes)
@@ -44,4 +47,39 @@ func (s *Server) handleGetPool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpjson.Write(w, http.StatusOK, pool)
+}
+
+func (s *Server) handleDrainPool(w http.ResponseWriter, r *http.Request) {
+	if s.poolMaintenance == nil {
+		httpjson.Error(w, http.StatusServiceUnavailable, "pool maintenance is not available")
+		return
+	}
+	p, err := s.poolMaintenance.Drain(r.Context(), model.PoolName(r.PathValue("name")))
+	s.writePoolMaintenanceResult(w, p, err, "drain")
+}
+
+func (s *Server) handleFillPool(w http.ResponseWriter, r *http.Request) {
+	if s.poolMaintenance == nil {
+		httpjson.Error(w, http.StatusServiceUnavailable, "pool maintenance is not available")
+		return
+	}
+	p, err := s.poolMaintenance.Fill(r.Context(), model.PoolName(r.PathValue("name")))
+	s.writePoolMaintenanceResult(w, p, err, "fill")
+}
+
+func (s *Server) writePoolMaintenanceResult(w http.ResponseWriter, p model.Pool, err error, action string) {
+	if errors.Is(err, store.ErrNotFound) {
+		httpjson.Error(w, http.StatusNotFound, "pool not found")
+		return
+	}
+	var configDrainErr *pool.ConfigDeclaredDrainError
+	if errors.As(err, &configDrainErr) {
+		httpjson.Error(w, http.StatusConflict, configDrainErr.Error())
+		return
+	}
+	if err != nil {
+		httpjson.Error(w, http.StatusInternalServerError, "failed to "+action+" pool: "+err.Error())
+		return
+	}
+	httpjson.Write(w, http.StatusOK, p)
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8,11 +8,33 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Geogboe/boxy/internal/pool"
 	"github.com/Geogboe/boxy/internal/sandbox"
 	"github.com/Geogboe/boxy/internal/server"
 	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/store"
 )
+
+type fakePoolMaintenance struct {
+	drainPool model.Pool
+	fillPool  model.Pool
+	drainErr  error
+	fillErr   error
+	drained   []model.PoolName
+	filled    []model.PoolName
+}
+
+func (m *fakePoolMaintenance) Drain(ctx context.Context, poolName model.PoolName) (model.Pool, error) {
+	_ = ctx
+	m.drained = append(m.drained, poolName)
+	return m.drainPool, m.drainErr
+}
+
+func (m *fakePoolMaintenance) Fill(ctx context.Context, poolName model.PoolName) (model.Pool, error) {
+	_ = ctx
+	m.filled = append(m.filled, poolName)
+	return m.fillPool, m.fillErr
+}
 
 func TestAPI_ListPools_empty(t *testing.T) {
 	t.Parallel()
@@ -430,5 +452,64 @@ func TestAPI_DeleteSandbox_notfound(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestAPI_DrainPool(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	maintenance := &fakePoolMaintenance{drainPool: model.Pool{
+		Name:  "web",
+		Drain: model.PoolDrainState{Operator: true},
+	}}
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false, maintenance)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/pools/web/drain", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if len(maintenance.drained) != 1 || maintenance.drained[0] != "web" {
+		t.Fatalf("drained = %v, want [web]", maintenance.drained)
+	}
+	var got model.Pool
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.Drain.Operator {
+		t.Fatalf("operator drain = false, want true")
+	}
+}
+
+func TestAPI_DrainPool_notFound(t *testing.T) {
+	t.Parallel()
+	maintenance := &fakePoolMaintenance{drainErr: store.ErrNotFound}
+	mux := server.NewTestMux(store.NewMemoryStore(), sandbox.New(store.NewMemoryStore(), nil), false, maintenance)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/pools/missing/drain", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_FillPool_ConfigDeclaredDrain(t *testing.T) {
+	t.Parallel()
+	maintenance := &fakePoolMaintenance{fillErr: &pool.ConfigDeclaredDrainError{PoolName: "web"}}
+	mux := server.NewTestMux(store.NewMemoryStore(), sandbox.New(store.NewMemoryStore(), nil), false, maintenance)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/pools/web/fill", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`configured drained`)) {
+		t.Fatalf("body = %s, want configured drained message", w.Body.String())
 	}
 }

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -8,11 +8,16 @@ import (
 )
 
 // NewTestMux creates a configured http.ServeMux for testing without starting a listener.
-func NewTestMux(st store.Store, sm *sandbox.Manager, uiEnabled bool) *http.ServeMux {
+func NewTestMux(st store.Store, sm *sandbox.Manager, uiEnabled bool, pm ...PoolMaintenance) *http.ServeMux {
+	var maintenance PoolMaintenance
+	if len(pm) > 0 {
+		maintenance = pm[0]
+	}
 	s := &Server{
-		store:      st,
-		sandboxMgr: sm,
-		uiEnabled:  uiEnabled,
+		store:           st,
+		sandboxMgr:      sm,
+		poolMaintenance: maintenance,
+		uiEnabled:       uiEnabled,
 	}
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,26 +16,35 @@ import (
 	"time"
 
 	"github.com/Geogboe/boxy/internal/sandbox"
+	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/store"
 )
 
+// PoolMaintenance performs operator pool maintenance actions for API handlers.
+type PoolMaintenance interface {
+	Drain(ctx context.Context, poolName model.PoolName) (model.Pool, error)
+	Fill(ctx context.Context, poolName model.PoolName) (model.Pool, error)
+}
+
 // Server is the HTTP server for the Boxy REST API and optional web UI.
 type Server struct {
-	store      store.Store
-	sandboxMgr *sandbox.Manager
-	uiEnabled  bool
-	addr       string
-	srv        *http.Server
+	store           store.Store
+	sandboxMgr      *sandbox.Manager
+	poolMaintenance PoolMaintenance
+	uiEnabled       bool
+	addr            string
+	srv             *http.Server
 }
 
 // New creates a Server that will listen on addr.
 // If uiEnabled is true, the web dashboard is served at /.
-func New(st store.Store, sm *sandbox.Manager, addr string, uiEnabled bool) *Server {
+func New(st store.Store, sm *sandbox.Manager, pm PoolMaintenance, addr string, uiEnabled bool) *Server {
 	s := &Server{
-		store:      st,
-		sandboxMgr: sm,
-		uiEnabled:  uiEnabled,
-		addr:       addr,
+		store:           st,
+		sandboxMgr:      sm,
+		poolMaintenance: pm,
+		uiEnabled:       uiEnabled,
+		addr:            addr,
 	}
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,7 +15,7 @@ func TestServer_healthz(t *testing.T) {
 	t.Parallel()
 
 	st := store.NewMemoryStore()
-	srv := server.New(st, sandbox.New(st, nil), ":0", false)
+	srv := server.New(st, sandbox.New(st, nil), nil, ":0", false)
 	_ = srv // we test via httptest below
 
 	// Use httptest to avoid binding a real port.
@@ -36,7 +36,7 @@ func TestServer_start_shutdown(t *testing.T) {
 	t.Parallel()
 
 	st := store.NewMemoryStore()
-	srv := server.New(st, sandbox.New(st, nil), "127.0.0.1:0", false)
+	srv := server.New(st, sandbox.New(st, nil), nil, "127.0.0.1:0", false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)

--- a/internal/skills/assets/boxy-cli/SKILL.md
+++ b/internal/skills/assets/boxy-cli/SKILL.md
@@ -23,6 +23,8 @@ Core commands you will commonly use:
 - `boxy sandbox get`
 - `boxy sandbox delete`
 - `boxy status`
+- `boxy debug pool drain`
+- `boxy debug pool fill`
 - `boxy debug provider list`
 - `boxy debug provider get`
 - `boxy debug provider exec`
@@ -38,6 +40,7 @@ Core commands you will commonly use:
 - Validate config with `boxy config validate` before telling the user to run `boxy serve`.
 - Prefer `boxy serve --once` for smoke checks and `boxy serve` for daemon usage.
 - Sandbox creation is asynchronous. Use `boxy sandbox create --no-wait` if you need the request accepted quickly, then poll with `boxy sandbox get`.
+- Use `boxy debug pool drain <pool>` and `boxy debug pool fill <pool>` for daemon-backed operator maintenance of unused ready pool inventory.
 - If a sandbox fails or stalls, use the diagnosis workflow instead of guessing.
 - Boxy persists daemon runtime state in `.boxy/state.json` near the active config or working directory; use that fact in diagnosis, not as the primary control interface.
 

--- a/pkg/model/pool.go
+++ b/pkg/model/pool.go
@@ -10,6 +10,9 @@ type Pool struct {
 	// Policies are pool-level behavioral controls (preheating, limits, etc).
 	Policies PoolPolicies `json:"policies,omitempty" yaml:"policies,omitempty"`
 
+	// Drain records desired drain state for unused pool inventory.
+	Drain PoolDrainState `json:"drain,omitempty" yaml:"drain,omitempty"`
+
 	// Inventory is the current contents of the pool.
 	Inventory ResourceCollection `json:"inventory" yaml:"inventory"`
 }
@@ -25,6 +28,26 @@ type PoolPolicies struct {
 	// This does NOT mean resources are returned to the pool after sandbox use.
 	// Resources remain single-use; recycle applies only to unused inventory.
 	Recycle RecyclePolicy `json:"recycle,omitempty" yaml:"recycle,omitempty"`
+}
+
+// PoolDrainState records whether a pool should destroy and avoid creating
+// unused ready inventory.
+type PoolDrainState struct {
+	// ConfigDeclared is true when config declares the pool drained.
+	ConfigDeclared bool `json:"config_declared,omitempty" yaml:"config_declared,omitempty"`
+
+	// Operator is a persisted operator/debug override.
+	Operator bool `json:"operator,omitempty" yaml:"operator,omitempty"`
+}
+
+// Effective reports whether either config or operator state keeps the pool drained.
+func (d PoolDrainState) Effective() bool {
+	return d.ConfigDeclared || d.Operator
+}
+
+// EffectivelyDrained reports whether the pool should currently be drained.
+func (p Pool) EffectivelyDrained() bool {
+	return p.Drain.Effective()
 }
 
 // PreheatPolicy is the pool policy for keeping resources ready ahead of time.

--- a/pkg/store/disk.go
+++ b/pkg/store/disk.go
@@ -142,6 +142,16 @@ func (s *DiskStore) PutResource(ctx context.Context, res model.Resource) error {
 	return s.persistLocked()
 }
 
+func (s *DiskStore) DeleteResource(_ context.Context, id model.ResourceID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.data.Resources[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.data.Resources, id)
+	return s.persistLocked()
+}
+
 func (s *DiskStore) GetSandbox(ctx context.Context, id model.SandboxID) (model.Sandbox, error) {
 	_ = ctx
 	s.mu.Lock()

--- a/pkg/store/memory.go
+++ b/pkg/store/memory.go
@@ -69,6 +69,16 @@ func (s *MemoryStore) PutResource(ctx context.Context, res model.Resource) error
 	return nil
 }
 
+func (s *MemoryStore) DeleteResource(_ context.Context, id model.ResourceID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.resources[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.resources, id)
+	return nil
+}
+
 func (s *MemoryStore) GetSandbox(ctx context.Context, id model.SandboxID) (model.Sandbox, error) {
 	_ = ctx
 	s.mu.Lock()

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -20,6 +20,7 @@ type Store interface {
 	// Resources
 	GetResource(ctx context.Context, id model.ResourceID) (model.Resource, error)
 	PutResource(ctx context.Context, res model.Resource) error
+	DeleteResource(ctx context.Context, id model.ResourceID) error
 
 	// Sandboxes
 	GetSandbox(ctx context.Context, id model.SandboxID) (model.Sandbox, error)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -162,6 +162,39 @@ func testStoreDeleteSandbox(t *testing.T, newStore storeFactory) {
 	})
 }
 
+func testStoreDeleteResource(t *testing.T, newStore storeFactory) {
+	t.Helper()
+
+	t.Run("DeleteResource_existing", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		s := newStore(t)
+		if err := s.PutResource(ctx, model.Resource{ID: "res-1"}); err != nil {
+			t.Fatalf("PutResource: %v", err)
+		}
+
+		if err := s.DeleteResource(ctx, "res-1"); err != nil {
+			t.Fatalf("DeleteResource: %v", err)
+		}
+
+		_, err := s.GetResource(ctx, "res-1")
+		if err != store.ErrNotFound {
+			t.Fatalf("GetResource after delete: got %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("DeleteResource_not_found", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		s := newStore(t)
+
+		err := s.DeleteResource(ctx, "no-such-id")
+		if err != store.ErrNotFound {
+			t.Fatalf("DeleteResource non-existent: got %v, want ErrNotFound", err)
+		}
+	})
+}
+
 func testStoreSandboxFieldsRoundTrip(t *testing.T, newStore storeFactory) {
 	t.Helper()
 
@@ -274,6 +307,16 @@ func TestMemoryStore_DeleteSandbox(t *testing.T) {
 func TestDiskStore_DeleteSandbox(t *testing.T) {
 	t.Parallel()
 	testStoreDeleteSandbox(t, diskFactory)
+}
+
+func TestMemoryStore_DeleteResource(t *testing.T) {
+	t.Parallel()
+	testStoreDeleteResource(t, memoryFactory)
+}
+
+func TestDiskStore_DeleteResource(t *testing.T) {
+	t.Parallel()
+	testStoreDeleteResource(t, diskFactory)
 }
 
 func TestMemoryStore_SandboxFieldsRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add explicit drain-to-zero pool semantics for configured `max_total: 0`
- Add daemon-backed `boxy debug pool drain` and `boxy debug pool fill` commands
- Persist operator drain overrides, delete drained resource records, and cover drain/fill behavior with regression tests

## Test plan
- `task fmt`
- `task skills:check`
- `task test`
- `task lint`
- `go test "-coverprofile=coverage.out" ./...` (total coverage: 60.2%)
- code review: no blocking issues
- PII/secrets scan: reviewed known historical/example findings with maintainer approval

Closes #116