### PR TITLE
fix: clean up resources during async sandbox deletion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
+* text=auto eol=lf
+
 *.sh text eol=lf
 *.sh.tmpl text eol=lf
+*.ps1 text eol=lf
 *.ps1.tmpl text eol=lf
-scripts/install.ps1 text eol=lf

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ boxy config validate                    — validate config file and exit
 boxy sandbox create -f <file>           — create sandbox from a spec file (waits by default; use --no-wait to return after acceptance)
 boxy sandbox list                       — list sandboxes
 boxy sandbox get <id>                   — get sandbox details
-boxy sandbox delete <id>                — delete a sandbox
+boxy sandbox delete <id>                — delete a sandbox (waits by default; use --no-wait to return after acceptance)
 ```
 
 **Planned (not yet implemented):**

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 
-version: '3'
-
+version: "3"
 
 tasks:
   default: task --list
@@ -10,9 +9,9 @@ tasks:
     desc: Run `boxy` via `go run`
     aliases:
       - run
-    dir: '{{.ROOT_DIR}}'
+    dir: "{{.ROOT_DIR}}"
     env:
-      BOXY_WORKING_DIR: '{{.USER_WORKING_DIR}}'
+      BOXY_WORKING_DIR: "{{.USER_WORKING_DIR}}"
     cmds:
       - go run ./cmd/boxy {{.CLI_ARGS}}
 
@@ -55,7 +54,7 @@ tasks:
 
   skills:install:dev:
     desc: Install the bundled skill into a local temp directory for manual inspection
-    dir: '{{.ROOT_DIR}}'
+    dir: "{{.ROOT_DIR}}"
     cmds:
       - go run ./cmd/boxy skills install --path ./.tmp/skills --force
 
@@ -83,18 +82,13 @@ tasks:
 
   fmt:
     desc: Format all Go source files
-    aliases:
-      - format
-    cmds:
-      - gofmt -w .
+    aliases: [format]
+    cmd: gofmt -w .
 
   lint:
     desc: Run golangci-lint (same as CI)
-    aliases:
-      - lint:go
-      - golangci-lint
-    cmds:
-      - go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...
+    aliases: [lint:go, golangci-lint]
+    cmd: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...
 
   release:check:
     desc: Validate GoReleaser config using the pinned tools module

--- a/cmd/boxy/main_test.go
+++ b/cmd/boxy/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRunVersionCommand(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"boxy", "--version"}
+
+	if code := run(); code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+}

--- a/cmd/schema-gen/main_test.go
+++ b/cmd/schema-gen/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildTopLevelSchemaIncludesProviderTypeRefs(t *testing.T) {
+	schema, err := buildTopLevelSchema()
+	if err != nil {
+		t.Fatalf("buildTopLevelSchema: %v", err)
+	}
+	if schema["$schema"] == "" || schema["type"] != "object" {
+		t.Fatalf("schema = %+v, want top-level object schema", schema)
+	}
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties = %#v, want map", schema["properties"])
+	}
+	providers, ok := properties["providers"].(map[string]any)
+	if !ok {
+		t.Fatalf("providers = %#v, want map", properties["providers"])
+	}
+	item, ok := providers["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("provider item = %#v, want map", providers["items"])
+	}
+	itemProperties, ok := item["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("item properties = %#v, want map", item["properties"])
+	}
+	typeSchema, ok := itemProperties["type"].(map[string]any)
+	if !ok {
+		t.Fatalf("type schema = %#v, want map", itemProperties["type"])
+	}
+	enum, ok := typeSchema["enum"].([]string)
+	if !ok {
+		t.Fatalf("type enum = %#v, want []string", typeSchema["enum"])
+	}
+	if len(enum) == 0 {
+		t.Fatal("provider type enum is empty")
+	}
+	allOf, ok := item["allOf"].([]any)
+	if !ok {
+		t.Fatalf("allOf = %#v, want []any", item["allOf"])
+	}
+	if len(allOf) != len(enum) {
+		t.Fatalf("allOf len = %d, want enum len %d", len(allOf), len(enum))
+	}
+}
+
+func TestMainWritesSchemaFile(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "schemas", "boxy.schema.json")
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"schema-gen", "-out", outPath}
+
+	main()
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, `"Boxy Configuration"`) || !strings.HasSuffix(body, "\n") {
+		t.Fatalf("schema body = %q, want generated formatted schema", body)
+	}
+}

--- a/docs/cli-wireframe.md
+++ b/docs/cli-wireframe.md
@@ -103,9 +103,13 @@ boxy
 │   │     {"id":"sb-a1b2c3","name":"pentest-lab","status":"ready",...}
 │   │
 │   └── delete <id>                              Delete a sandbox
+│       └── --no-wait                            Return after delete request is accepted
 │
 │       $ boxy sandbox delete sb-a1b2c3
 │         deleted sandbox sb-a1b2c3
+│
+│       $ boxy sandbox delete sb-a1b2c3 --no-wait
+│         accepted deletion of sandbox sb-a1b2c3
 │
 │
 ├── skills                                     Install bundled coding-agent skills

--- a/internal/cli/api_client.go
+++ b/internal/cli/api_client.go
@@ -52,6 +52,17 @@ func postJSON[TReq any, TResp any](ctx context.Context, client *http.Client, url
 	return doJSON[TResp](client, req)
 }
 
+func deleteJSON[T any](ctx context.Context, client *http.Client, url string) (T, error) {
+	var zero T
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return zero, err
+	}
+
+	return doJSON[T](client, req)
+}
+
 func doJSON[T any](client *http.Client, req *http.Request) (T, error) {
 	var zero T
 
@@ -71,21 +82,6 @@ func doJSON[T any](client *http.Client, req *http.Request) (T, error) {
 	}
 
 	return v, nil
-}
-
-func deleteAPI(ctx context.Context, client *http.Client, url string) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
-	if err != nil {
-		return 0, err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	return resp.StatusCode, nil
 }
 
 func decodeAPIError(resp *http.Response, url string) error {
@@ -121,4 +117,8 @@ func apiBaseURL(server string) string {
 
 func defaultAPIClient() *http.Client {
 	return &http.Client{Timeout: 5 * time.Second}
+}
+
+func maintenanceAPIClient() *http.Client {
+	return &http.Client{}
 }

--- a/internal/cli/api_client_test.go
+++ b/internal/cli/api_client_test.go
@@ -1,0 +1,12 @@
+package cli
+
+import "testing"
+
+func TestMaintenanceAPIClientHasNoFixedTimeout(t *testing.T) {
+	if maintenanceAPIClient().Timeout != 0 {
+		t.Fatalf("maintenance client timeout = %v, want no fixed timeout", maintenanceAPIClient().Timeout)
+	}
+	if defaultAPIClient().Timeout == 0 {
+		t.Fatal("default API client should keep a short timeout")
+	}
+}

--- a/internal/cli/debug_pool.go
+++ b/internal/cli/debug_pool.go
@@ -31,7 +31,7 @@ func newDebugPoolDrainCommand(serverAddr func() string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pool, err := postJSON[map[string]any, model.Pool](
 				cmd.Context(),
-				defaultAPIClient(),
+				maintenanceAPIClient(),
 				apiBaseURL(serverAddr())+"/api/v1/pools/"+args[0]+"/drain",
 				map[string]any{},
 			)
@@ -52,7 +52,7 @@ func newDebugPoolFillCommand(serverAddr func() string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pool, err := postJSON[map[string]any, model.Pool](
 				cmd.Context(),
-				defaultAPIClient(),
+				maintenanceAPIClient(),
 				apiBaseURL(serverAddr())+"/api/v1/pools/"+args[0]+"/fill",
 				map[string]any{},
 			)

--- a/internal/cli/sandbox_create_test.go
+++ b/internal/cli/sandbox_create_test.go
@@ -361,3 +361,42 @@ func TestWaitForSandboxReady_Interrupted(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestWaitForSandboxReady_ReturnsPollingAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"database unavailable"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, err := waitForSandboxReady(context.Background(), defaultAPIClient(), srv.URL, model.Sandbox{
+		ID:     "sb-create",
+		Name:   "lab",
+		Status: model.SandboxStatusPending,
+	})
+	if err == nil {
+		t.Fatal("expected polling error")
+	}
+	if !strings.Contains(err.Error(), "database unavailable") {
+		t.Fatalf("error = %v, want server message", err)
+	}
+}
+
+func TestHydrateSandboxResourcesSkipsMissingResources(t *testing.T) {
+	srv := newSandboxCreateTestServer(t)
+	defer srv.Close()
+
+	resources, err := hydrateSandboxResources(context.Background(), defaultAPIClient(), srv.server.URL, model.Sandbox{
+		ID:        "sb-create",
+		Resources: []model.ResourceID{"res-1", "missing"},
+	})
+	if err != nil {
+		t.Fatalf("hydrateSandboxResources: %v", err)
+	}
+	if len(resources) != 1 || resources[0].ID != "res-1" {
+		t.Fatalf("resources = %+v, want only res-1", resources)
+	}
+}

--- a/internal/cli/sandbox_delete.go
+++ b/internal/cli/sandbox_delete.go
@@ -1,35 +1,74 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
+	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/spf13/cobra"
 )
 
 func newSandboxDeleteCommand(serverAddr func() string) *cobra.Command {
-	return &cobra.Command{
+	var noWait bool
+	cmd := &cobra.Command{
 		Use:   "delete <id>",
 		Short: "Delete a sandbox by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := defaultAPIClient()
 			base := apiBaseURL(serverAddr())
+			id := args[0]
 
-			status, err := deleteAPI(cmd.Context(), client, base+"/api/v1/sandboxes/"+args[0])
+			sb, err := deleteJSON[model.Sandbox](cmd.Context(), client, base+"/api/v1/sandboxes/"+id)
 			if err != nil {
-				return fmt.Errorf("delete sandbox %q: %w", args[0], err)
+				var apiErr *apiError
+				if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+					return fmt.Errorf("sandbox %q not found", id)
+				}
+				return fmt.Errorf("delete sandbox %q: %w", id, err)
 			}
-
-			switch status {
-			case http.StatusNoContent:
-				fmt.Printf("deleted sandbox %s\n", args[0])
+			if noWait {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "accepted deletion of sandbox %s\n", sb.ID)
 				return nil
-			case http.StatusNotFound:
-				return fmt.Errorf("sandbox %q not found", args[0])
-			default:
-				return fmt.Errorf("delete sandbox %q: unexpected status %d", args[0], status)
 			}
+			if err := waitForSandboxDeleted(cmd.Context(), client, base, sb.ID); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "deleted sandbox %s\n", sb.ID)
+			return nil
 		},
+	}
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Return after delete request is accepted")
+	return cmd
+}
+
+func waitForSandboxDeleted(ctx context.Context, client *http.Client, base string, id model.SandboxID) error {
+	ticker := time.NewTicker(sandboxPollInterval)
+	defer ticker.Stop()
+
+	for {
+		_, err := fetchJSON[model.Sandbox](ctx, client, base+"/api/v1/sandboxes/"+string(id))
+		if err == nil {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("sandbox %q deletion accepted but wait was interrupted: %w", id, ctx.Err())
+			case <-ticker.C:
+			}
+			continue
+		}
+		var apiErr *apiError
+		if errors.As(err, &apiErr) {
+			if apiErr.StatusCode == http.StatusNotFound {
+				return nil
+			}
+			return fmt.Errorf("wait for sandbox %q deletion: %w", id, err)
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("sandbox %q deletion accepted but wait was interrupted: %w", id, err)
+		}
+		return fmt.Errorf("wait for sandbox %q deletion: %w", id, err)
 	}
 }

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -116,12 +116,19 @@ func newSandboxTestServer(t *testing.T, listItems []model.Sandbox) *httptest.Ser
 	})
 	mux.HandleFunc("DELETE /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		if _, ok := sandboxes[id]; !ok {
+		sb, ok := sandboxes[id]
+		if !ok {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+		sb.Status = model.SandboxStatusDeleting
+		sandboxes[id] = sb
 		delete(sandboxes, id)
-		w.WriteHeader(http.StatusNoContent)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := printJSONTo(w, sb); err != nil {
+			t.Fatalf("encode sandbox delete: %v", err)
+		}
 	})
 
 	return httptest.NewServer(mux)
@@ -230,7 +237,28 @@ func TestSandboxDelete_found(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
+
 	if !strings.Contains(output, "deleted sandbox sb-1") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestSandboxDelete_NoWaitReturnsAfterAccepted(t *testing.T) {
+	srv := newSandboxTestServer(t, []model.Sandbox{
+		{ID: "sb-1", Name: "one", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1"}},
+	})
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.URL, "delete", "sb-1", "--no-wait"})
+
+	output, err := captureSandboxStdout(t, func() error {
+		return cmd.ExecuteContext(context.Background())
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(output, "accepted deletion of sandbox sb-1") {
 		t.Fatalf("output = %q", output)
 	}
 }
@@ -251,5 +279,57 @@ func TestSandboxDelete_not_found(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `sandbox "no-such-id" not found`) {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWaitForSandboxDeleted_ReturnsNilOnNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if err := waitForSandboxDeleted(context.Background(), defaultAPIClient(), srv.URL, "sb-1"); err != nil {
+		t.Fatalf("waitForSandboxDeleted: %v", err)
+	}
+}
+
+func TestWaitForSandboxDeleted_ReturnsServerErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"cleanup status unavailable"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := waitForSandboxDeleted(context.Background(), defaultAPIClient(), srv.URL, "sb-1")
+	if err == nil {
+		t.Fatal("expected wait error")
+	}
+	if !strings.Contains(err.Error(), "cleanup status unavailable") {
+		t.Fatalf("error = %v, want server message", err)
+	}
+}
+
+func TestWaitForSandboxDeleted_InterruptedWhileSandboxStillExists(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = printJSONTo(w, model.Sandbox{ID: "sb-1", Status: model.SandboxStatusDeleting})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := waitForSandboxDeleted(ctx, defaultAPIClient(), srv.URL, "sb-1")
+	if err == nil {
+		t.Fatal("expected interrupted wait error")
+	}
+	if !strings.Contains(err.Error(), "deletion accepted but wait was interrupted") {
+		t.Fatalf("error = %v, want interrupted message", err)
 	}
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -136,6 +136,7 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 	poolMgr := pool.New(st, provisioner)
 	sandboxMgr := sandbox.New(st, provisioner)
 	sandboxFulfiller := sandbox.NewFulfiller(st, poolMgr, sandboxMgr)
+	sandboxDeleter := sandbox.NewDeletionReconciler(st, poolMgr)
 
 	// Pools
 	donePools, failPools := ui.step("Initializing pools")
@@ -159,7 +160,7 @@ func runServe(ctx context.Context, opts serveOpts, cmd *cobra.Command) error {
 		return srv.Start(ctx)
 	})
 	g.Go(func() error {
-		return serveLoop(ctx, poolMgr, sandboxFulfiller, poolNames, ui)
+		return serveLoop(ctx, poolMgr, sandboxDeleter, sandboxFulfiller, poolNames, ui)
 	})
 
 	printServeBanner(listenAddr, uiEnabled, len(cfg.Pools))
@@ -291,6 +292,7 @@ func findDefaultConfigPath() (string, error) {
 func serveLoop(
 	ctx context.Context,
 	poolMgr servePoolReconciler,
+	sandboxDeleter serveSandboxReconciler,
 	sandboxFulfiller serveSandboxReconciler,
 	poolNames []model.PoolName,
 	ui *serveUI,
@@ -306,7 +308,7 @@ func serveLoop(
 			ui.shutdown()
 			return nil
 		case <-ticker.C:
-			serveReconcilePass(ctx, poolMgr, sandboxFulfiller, poolNames, ui)
+			serveReconcilePass(ctx, poolMgr, sandboxDeleter, sandboxFulfiller, poolNames, ui)
 		}
 	}
 }
@@ -328,6 +330,7 @@ func (f serveSandboxReconcilerFunc) Reconcile(ctx context.Context) error {
 func serveReconcilePass(
 	ctx context.Context,
 	poolMgr servePoolReconciler,
+	sandboxDeleter serveSandboxReconciler,
 	sandboxFulfiller serveSandboxReconciler,
 	poolNames []model.PoolName,
 	ui *serveUI,
@@ -340,9 +343,16 @@ func serveReconcilePass(
 		}
 	}
 
+	if sandboxDeleter != nil {
+		if err := sandboxDeleter.Reconcile(ctx); err != nil {
+			ui.printErr(err)
+		}
+	}
 	reconcilePools()
-	if err := sandboxFulfiller.Reconcile(ctx); err != nil {
-		ui.printErr(err)
+	if sandboxFulfiller != nil {
+		if err := sandboxFulfiller.Reconcile(ctx); err != nil {
+			ui.printErr(err)
+		}
 	}
 	reconcilePools()
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -9,11 +9,42 @@ import (
 
 	boxyconfig "github.com/Geogboe/boxy/internal/config"
 	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/providersdk"
 	"github.com/Geogboe/boxy/pkg/store"
 )
 
 type fakeServePoolReconciler struct {
 	calls []model.PoolName
+}
+
+type servePoolReconcilerFunc func(ctx context.Context, poolName model.PoolName) error
+
+func (f servePoolReconcilerFunc) Reconcile(ctx context.Context, poolName model.PoolName) error {
+	return f(ctx, poolName)
+}
+
+type serveDriverConfig struct {
+	Image string `json:"image"`
+}
+
+type serveDriver struct {
+	providerType providersdk.Type
+	cfg          any
+}
+
+func (d serveDriver) Type() providersdk.Type { return d.providerType }
+func (d serveDriver) Create(context.Context, any) (*providersdk.Resource, error) {
+	return &providersdk.Resource{}, nil
+}
+func (d serveDriver) Read(context.Context, string) (*providersdk.ResourceStatus, error) {
+	return &providersdk.ResourceStatus{}, nil
+}
+func (d serveDriver) Update(context.Context, string, providersdk.Operation) (*providersdk.Result, error) {
+	return &providersdk.Result{}, nil
+}
+func (d serveDriver) Delete(context.Context, string) error { return nil }
+func (d serveDriver) Allocate(context.Context, string) (map[string]any, error) {
+	return nil, nil
 }
 
 func (r *fakeServePoolReconciler) Reconcile(ctx context.Context, poolName model.PoolName) error {
@@ -38,7 +69,7 @@ func TestServeReconcilePass_ReconcilesPoolsBeforeAndAfterSandboxFulfillment(t *t
 	pools := &fakeServePoolReconciler{}
 	sandboxes := &fakeServeSandboxReconciler{}
 
-	serveReconcilePass(context.Background(), pools, sandboxes, []model.PoolName{"web", "win"}, newServeUI(false))
+	serveReconcilePass(context.Background(), pools, nil, sandboxes, []model.PoolName{"web", "win"}, newServeUI(false))
 
 	if sandboxes.calls != 1 {
 		t.Fatalf("sandbox reconcile calls = %d, want 1", sandboxes.calls)
@@ -55,6 +86,149 @@ func TestServeReconcilePass_ReconcilesPoolsBeforeAndAfterSandboxFulfillment(t *t
 	}
 }
 
+func TestResolveServeOptionsPreferFlagsThenConfigDefaults(t *testing.T) {
+	cfgUIFalse := false
+	cfg := boxyconfig.Config{
+		Server: boxyconfig.ServerSpec{Listen: ":7777", UI: &cfgUIFalse},
+	}
+
+	cmd := newServeCommand()
+	if got := resolveListenAddr(serveOpts{}, cmd, cfg); got != ":7777" {
+		t.Fatalf("resolveListenAddr config = %q, want :7777", got)
+	}
+	if got := resolveUIEnabled(serveOpts{}, cmd, cfg); got {
+		t.Fatal("resolveUIEnabled config = true, want false")
+	}
+
+	cmd = newServeCommand()
+	if err := cmd.Flags().Set("listen", ":8888"); err != nil {
+		t.Fatalf("set listen: %v", err)
+	}
+	if err := cmd.Flags().Set("ui", "true"); err != nil {
+		t.Fatalf("set ui: %v", err)
+	}
+	if got := resolveListenAddr(serveOpts{listen: ":8888"}, cmd, cfg); got != ":8888" {
+		t.Fatalf("resolveListenAddr flag = %q, want :8888", got)
+	}
+	if got := resolveUIEnabled(serveOpts{ui: true}, cmd, cfg); !got {
+		t.Fatal("resolveUIEnabled flag = false, want true")
+	}
+
+	cmd = newServeCommand()
+	if got := resolveListenAddr(serveOpts{}, cmd, boxyconfig.Config{}); got != defaultListenAddr {
+		t.Fatalf("resolveListenAddr default = %q, want %q", got, defaultListenAddr)
+	}
+	if got := resolveUIEnabled(serveOpts{}, cmd, boxyconfig.Config{}); !got {
+		t.Fatal("resolveUIEnabled default = false, want true")
+	}
+}
+
+func TestLoadConfigFindsDefaultConfigInEffectiveWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BOXY_WORKING_DIR", dir)
+	cfgPath := filepath.Join(dir, "boxy.yml")
+	if err := os.WriteFile(cfgPath, []byte("providers: []\npools: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, usedPath, err := loadConfig("")
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if usedPath != cfgPath {
+		t.Fatalf("usedPath = %q, want %q", usedPath, cfgPath)
+	}
+	if len(cfg.Providers) != 0 || len(cfg.Pools) != 0 {
+		t.Fatalf("cfg = %+v, want empty config from default file", cfg)
+	}
+}
+
+func TestLoadConfigReturnsDefaultsWhenNoConfigFileExists(t *testing.T) {
+	t.Setenv("BOXY_WORKING_DIR", t.TempDir())
+
+	cfg, usedPath, err := loadConfig("")
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if usedPath != "" {
+		t.Fatalf("usedPath = %q, want empty", usedPath)
+	}
+	if len(cfg.Providers) != 0 || len(cfg.Pools) != 0 {
+		t.Fatalf("cfg = %+v, want zero-value config", cfg)
+	}
+}
+
+func TestDisplayAddr(t *testing.T) {
+	tests := map[string]string{
+		":9090":        "127.0.0.1:9090",
+		"0.0.0.0:9090": "127.0.0.1:9090",
+		"localhost:80": "localhost:80",
+	}
+	for input, want := range tests {
+		if got := displayAddr(input); got != want {
+			t.Fatalf("displayAddr(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestBuildDriversDecodesConfiguredInstancesAndDefaults(t *testing.T) {
+	reg := providersdk.NewRegistry()
+	var configs []any
+	for _, typ := range []providersdk.Type{"alpha", "beta"} {
+		typ := typ
+		if err := reg.Register(providersdk.Registration{
+			Type:        typ,
+			ConfigProto: func() any { return &serveDriverConfig{} },
+			NewDriver: func(cfg any) (providersdk.Driver, error) {
+				configs = append(configs, cfg)
+				return serveDriver{providerType: typ, cfg: cfg}, nil
+			},
+		}); err != nil {
+			t.Fatalf("register %q: %v", typ, err)
+		}
+	}
+
+	drivers, err := buildDrivers(reg, []providersdk.Instance{
+		{Name: "alpha-local", Type: "alpha", Config: map[string]any{"image": "alpine"}},
+	})
+	if err != nil {
+		t.Fatalf("buildDrivers: %v", err)
+	}
+	if len(drivers) != 2 {
+		t.Fatalf("drivers len = %d, want 2", len(drivers))
+	}
+	if types := providerTypes(reg); len(types) != 2 || types[0] != "alpha" || types[1] != "beta" {
+		t.Fatalf("providerTypes = %v, want [alpha beta]", types)
+	}
+	if cfg, ok := configs[0].(*serveDriverConfig); !ok || cfg.Image != "alpine" {
+		t.Fatalf("alpha config = %#v, want decoded image", configs[0])
+	}
+	if cfg, ok := configs[1].(*serveDriverConfig); !ok || cfg.Image != "" {
+		t.Fatalf("beta config = %#v, want zero-value default", configs[1])
+	}
+}
+
+func TestBuildDriversReportsDecodeAndFactoryErrors(t *testing.T) {
+	reg := providersdk.NewRegistry()
+	if err := reg.Register(providersdk.Registration{
+		Type:        "alpha",
+		ConfigProto: func() any { return &serveDriverConfig{} },
+		NewDriver: func(any) (providersdk.Driver, error) {
+			return nil, fmt.Errorf("factory failed")
+		},
+	}); err != nil {
+		t.Fatalf("register alpha: %v", err)
+	}
+
+	if _, err := buildDrivers(reg, []providersdk.Instance{{Name: "alpha-local", Type: "alpha", Config: map[string]any{"image": map[string]any{"bad": true}}}}); err == nil {
+		t.Fatal("buildDrivers decode error = nil")
+	}
+
+	if _, err := buildDrivers(reg, nil); err == nil {
+		t.Fatal("buildDrivers factory error = nil")
+	}
+}
+
 func TestServeReconcilePass_RunsPostFulfillmentPoolReconcileEvenAfterSandboxError(t *testing.T) {
 	t.Parallel()
 
@@ -64,7 +238,7 @@ func TestServeReconcilePass_RunsPostFulfillmentPoolReconcileEvenAfterSandboxErro
 		return fmt.Errorf("boom")
 	})
 
-	serveReconcilePass(context.Background(), pools, sandboxes, []model.PoolName{"web"}, newServeUI(false))
+	serveReconcilePass(context.Background(), pools, nil, sandboxes, []model.PoolName{"web"}, newServeUI(false))
 
 	want := []model.PoolName{"web", "web"}
 	if len(pools.calls) != len(want) {
@@ -73,6 +247,39 @@ func TestServeReconcilePass_RunsPostFulfillmentPoolReconcileEvenAfterSandboxErro
 	for i := range want {
 		if pools.calls[i] != want[i] {
 			t.Fatalf("pool reconcile calls = %v, want %v", pools.calls, want)
+		}
+	}
+}
+
+func TestServeReconcilePass_DeletesSandboxesBeforePoolRefill(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+	pools := servePoolReconcilerFunc(func(ctx context.Context, poolName model.PoolName) error {
+		_ = ctx
+		order = append(order, "pool:"+string(poolName))
+		return nil
+	})
+	deleter := serveSandboxReconcilerFunc(func(ctx context.Context) error {
+		_ = ctx
+		order = append(order, "delete")
+		return nil
+	})
+	fulfiller := serveSandboxReconcilerFunc(func(ctx context.Context) error {
+		_ = ctx
+		order = append(order, "fulfill")
+		return nil
+	})
+
+	serveReconcilePass(context.Background(), pools, deleter, fulfiller, []model.PoolName{"web"}, newServeUI(false))
+
+	want := []string{"delete", "pool:web", "fulfill", "pool:web"}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v, want %v", order, want)
 		}
 	}
 }

--- a/internal/config/pool_spec_test.go
+++ b/internal/config/pool_spec_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPoolSpecUnmarshalJSONTracksPolicyAliasesAndExplicitDrain(t *testing.T) {
+	var policy PoolSpec
+	if err := json.Unmarshal([]byte(`{
+		"name":"web",
+		"type":"container",
+		"provider":"docker-local",
+		"config":{"image":"alpine"},
+		"policy":{"preheat":{"min_ready":0,"max_total":0},"recycle":{"max_age":"1h"}}
+	}`), &policy); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+	if !policy.PolicySet() || policy.PoliciesSet() {
+		t.Fatalf("policy flags policy=%t policies=%t, want only policy", policy.PolicySet(), policy.PoliciesSet())
+	}
+	if !policy.EffectivePolicy().Preheat.MaxTotalSet() || !policy.EffectivePolicy().Preheat.ConfiguresDrain() {
+		t.Fatalf("preheat = %+v, want explicit max_total drain", policy.EffectivePolicy().Preheat)
+	}
+	if policy.EffectivePolicy().Recycle.MaxAge != "1h" {
+		t.Fatalf("recycle max_age = %q, want 1h", policy.EffectivePolicy().Recycle.MaxAge)
+	}
+
+	var policies PoolSpec
+	if err := json.Unmarshal([]byte(`{"name":"web","policies":{"preheat":{"max_total":2}}}`), &policies); err != nil {
+		t.Fatalf("unmarshal policies: %v", err)
+	}
+	if policies.PolicySet() || !policies.PoliciesSet() {
+		t.Fatalf("alias flags policy=%t policies=%t, want only policies", policies.PolicySet(), policies.PoliciesSet())
+	}
+	if policies.EffectivePolicy().Preheat.MaxTotal != 2 || !policies.EffectivePolicy().Preheat.MaxTotalSet() {
+		t.Fatalf("preheat = %+v, want explicit max_total 2", policies.EffectivePolicy().Preheat)
+	}
+}
+
+func TestPoolSpecUnmarshalYAMLTracksExplicitPreheatFields(t *testing.T) {
+	var spec PoolSpec
+	if err := yaml.Unmarshal([]byte(`
+name: win
+type: vm
+provider: hyperv-local
+config:
+  template_vhd: base.vhdx
+policy:
+  preheat:
+    min_ready: 0
+    max_total: 0
+  recycle:
+    max_age: 2h
+`), &spec); err != nil {
+		t.Fatalf("unmarshal yaml: %v", err)
+	}
+	if !spec.PolicySet() || spec.PoliciesSet() {
+		t.Fatalf("policy flags policy=%t policies=%t, want only policy", spec.PolicySet(), spec.PoliciesSet())
+	}
+	preheat := spec.EffectivePolicy().Preheat
+	if !preheat.MinReadySet() || !preheat.MaxTotalSet() || !preheat.ConfiguresDrain() {
+		t.Fatalf("preheat = %+v, want explicit min_ready/max_total drain", preheat)
+	}
+	if spec.EffectivePolicy().Recycle.MaxAge != "2h" {
+		t.Fatalf("recycle max_age = %q, want 2h", spec.EffectivePolicy().Recycle.MaxAge)
+	}
+}
+
+func TestPoolSpecUnmarshalRejectsUnknownFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "pool field", body: `{"name":"web","unknown":true}`, want: `unknown field "unknown"`},
+		{name: "policy field", body: `{"name":"web","policy":{"unknown":true}}`, want: `unknown field "unknown"`},
+		{name: "preheat field", body: `{"name":"web","policy":{"preheat":{"unknown":true}}}`, want: `unknown field "unknown"`},
+		{name: "recycle field", body: `{"name":"web","policy":{"recycle":{"unknown":true}}}`, want: `unknown field "unknown"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var spec PoolSpec
+			err := json.Unmarshal([]byte(tt.body), &spec)
+			if err == nil {
+				t.Fatalf("json unmarshal error = nil, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("json unmarshal error = %q, want containing %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestPoolSpecUnmarshalYAMLRejectsBadShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "pool scalar", body: `not-a-map`, want: "pool spec must be a mapping"},
+		{name: "policy scalar", body: "name: web\npolicy: nope\n", want: "pool policy must be a mapping"},
+		{name: "preheat scalar", body: "name: web\npolicy:\n  preheat: nope\n", want: "preheat policy must be a mapping"},
+		{name: "recycle scalar", body: "name: web\npolicy:\n  recycle: nope\n", want: "recycle policy must be a mapping"},
+		{name: "pool unknown", body: "name: web\nunknown: true\n", want: "field unknown not found"},
+		{name: "policy unknown", body: "name: web\npolicy:\n  unknown: true\n", want: "field unknown not found"},
+		{name: "preheat unknown", body: "name: web\npolicy:\n  preheat:\n    unknown: true\n", want: "field unknown not found"},
+		{name: "recycle unknown", body: "name: web\npolicy:\n  recycle:\n    unknown: true\n", want: "field unknown not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var spec PoolSpec
+			err := yaml.Unmarshal([]byte(tt.body), &spec)
+			if err == nil {
+				t.Fatalf("yaml unmarshal error = nil, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("yaml unmarshal error = %q, want containing %q", err.Error(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -176,6 +176,55 @@ func (m *Manager) Fill(ctx context.Context, poolName model.PoolName) (model.Pool
 	return m.store.GetPool(ctx, poolName)
 }
 
+// DestroyResource tears down a tracked resource through its origin pool's
+// provider lifecycle and removes Boxy's resource record. Resources are
+// single-use; this never returns resources to ready inventory.
+func (m *Manager) DestroyResource(ctx context.Context, res model.Resource) error {
+	if m == nil {
+		return fmt.Errorf("pool manager is nil")
+	}
+	if m.store == nil {
+		return fmt.Errorf("store is nil")
+	}
+	if m.provisioner == nil {
+		return fmt.Errorf("provisioner is nil")
+	}
+	if res.ID == "" {
+		return fmt.Errorf("resource id is required")
+	}
+	if res.OriginPool == "" {
+		return fmt.Errorf("resource %q has no origin pool", res.ID)
+	}
+
+	unlock := m.lockPool(res.OriginPool)
+	defer unlock()
+
+	p, err := m.store.GetPool(ctx, res.OriginPool)
+	if errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("origin pool %q for resource %q not found", res.OriginPool, res.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("get origin pool %q for resource %q: %w", res.OriginPool, res.ID, err)
+	}
+
+	if err := m.provisioner.Destroy(ctx, p, res); err != nil {
+		return fmt.Errorf("destroy resource %q in pool %q: %w", res.ID, p.Name, err)
+	}
+	res.State = model.ResourceStateDestroyed
+	res.UpdatedAt = m.clock.Now()
+	if err := m.store.PutResource(ctx, res); err != nil {
+		return fmt.Errorf("mark resource %q destroyed: %w", res.ID, err)
+	}
+	p.Inventory.Resources = removeInventoryResource(p.Inventory.Resources, res.ID)
+	if err := m.store.PutPool(ctx, p); err != nil {
+		return fmt.Errorf("put pool %q after destroying resource %q: %w", p.Name, res.ID, err)
+	}
+	if err := m.store.DeleteResource(ctx, res.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("delete resource %q: %w", res.ID, err)
+	}
+	return nil
+}
+
 func (m *Manager) lockPool(poolName model.PoolName) func() {
 	m.locksMu.Lock()
 	if m.poolLocks == nil {

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -84,6 +84,124 @@ func TestManager_Reconcile_PrefillMinReady(t *testing.T) {
 	}
 }
 
+func TestManager_DestroyResource_DestroysAndDeletesWithoutReturningToInventory(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{
+		ID:         "res-allocated",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "web",
+		State:      model.ResourceStateAllocated,
+	}
+	if err := st.PutResource(ctx, res); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "web",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+			Resources:       []model.Resource{res},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+	if err := mgr.DestroyResource(ctx, res); err != nil {
+		t.Fatalf("DestroyResource: %v", err)
+	}
+
+	if len(prov.destroyed) != 1 || prov.destroyed[0] != res.ID {
+		t.Fatalf("destroyed = %v, want [%s]", prov.destroyed, res.ID)
+	}
+	if _, err := st.GetResource(ctx, res.ID); err != store.ErrNotFound {
+		t.Fatalf("resource after destroy err = %v, want ErrNotFound", err)
+	}
+	p, err := st.GetPool(ctx, "web")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(p.Inventory.Resources) != 0 {
+		t.Fatalf("inventory resources = %+v, want empty", p.Inventory.Resources)
+	}
+}
+
+func TestManager_DestroyResource_MissingOriginPoolFailsBeforeDestroy(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{
+		ID:         "res-allocated",
+		OriginPool: "missing",
+		State:      model.ResourceStateAllocated,
+	}
+
+	prov := &fakeProvisioner{}
+	mgr := New(st, prov)
+
+	err := mgr.DestroyResource(ctx, res)
+	if err == nil {
+		t.Fatal("expected missing origin pool error")
+	}
+	if len(prov.destroyed) != 0 {
+		t.Fatalf("destroyed = %v, want none", prov.destroyed)
+	}
+}
+
+func TestManager_DestroyResource_IgnoresMissingResourceRecordAfterProviderDelete(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{
+		ID:         "res-allocated",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "web",
+		State:      model.ResourceStateAllocated,
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "web",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	failingStore := &deleteFailStore{Store: st, err: store.ErrNotFound}
+	prov := &fakeProvisioner{}
+	if err := New(failingStore, prov).DestroyResource(ctx, res); err != nil {
+		t.Fatalf("DestroyResource: %v", err)
+	}
+	if len(prov.destroyed) != 1 || prov.destroyed[0] != res.ID {
+		t.Fatalf("destroyed = %v, want [%s]", prov.destroyed, res.ID)
+	}
+}
+
+func TestManager_DestroyResource_ValidatesInputsBeforeProviderDelete(t *testing.T) {
+	tests := []struct {
+		name string
+		mgr  *Manager
+		res  model.Resource
+	}{
+		{name: "nil manager", mgr: nil, res: model.Resource{ID: "res-1", OriginPool: "web"}},
+		{name: "nil store", mgr: New(nil, &fakeProvisioner{}), res: model.Resource{ID: "res-1", OriginPool: "web"}},
+		{name: "nil provisioner", mgr: New(store.NewMemoryStore(), nil), res: model.Resource{ID: "res-1", OriginPool: "web"}},
+		{name: "empty resource id", mgr: New(store.NewMemoryStore(), &fakeProvisioner{}), res: model.Resource{OriginPool: "web"}},
+		{name: "empty origin pool", mgr: New(store.NewMemoryStore(), &fakeProvisioner{}), res: model.Resource{ID: "res-1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mgr.DestroyResource(context.Background(), tt.res)
+			if err == nil {
+				t.Fatal("DestroyResource error = nil, want validation error")
+			}
+		})
+	}
+}
+
 func TestManager_Reconcile_RecycleStale(t *testing.T) {
 	st := store.NewMemoryStore()
 	old := model.Resource{

--- a/internal/pool/provisioner_agent_test.go
+++ b/internal/pool/provisioner_agent_test.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,21 +12,38 @@ import (
 	"github.com/Geogboe/boxy/pkg/providersdk"
 )
 
+var (
+	errAgentDeleteFailed = errors.New("agent delete failed")
+	errPersonalizeFailed = errors.New("personalize failed")
+)
+
 // mockAgent is a minimal test double for agentsdk.Agent.
 type mockAgent struct {
 	info           agentsdk.AgentInfo
 	createCalls    []mockCreateCall
-	deleteCalls    []string
+	deleteCalls    []mockDeleteCall
+	allocateCalls  []mockAllocateCall
 	nextResourceID string
 	createErr      error
 	deleteErr      error
 	allocateResult map[string]any
 	personalized   *providersdk.GuestPersonalizationResult
+	personalizeErr error
 }
 
 type mockCreateCall struct {
 	driverType providersdk.Type
 	cfg        any
+}
+
+type mockDeleteCall struct {
+	driverType providersdk.Type
+	id         string
+}
+
+type mockAllocateCall struct {
+	driverType providersdk.Type
+	id         string
 }
 
 func newMockAgent(providers ...providersdk.Type) *mockAgent {
@@ -63,15 +81,19 @@ func (m *mockAgent) Update(ctx context.Context, provider providersdk.Type, id st
 }
 
 func (m *mockAgent) Delete(ctx context.Context, provider providersdk.Type, id string) error {
-	m.deleteCalls = append(m.deleteCalls, id)
+	m.deleteCalls = append(m.deleteCalls, mockDeleteCall{driverType: provider, id: id})
 	return m.deleteErr
 }
 
 func (m *mockAgent) Allocate(ctx context.Context, provider providersdk.Type, id string) (map[string]any, error) {
+	m.allocateCalls = append(m.allocateCalls, mockAllocateCall{driverType: provider, id: id})
 	return m.allocateResult, nil
 }
 
 func (m *mockAgent) PersonalizeGuest(ctx context.Context, provider providersdk.Type, id string) (*providersdk.GuestPersonalizationResult, error) {
+	if m.personalizeErr != nil {
+		return nil, m.personalizeErr
+	}
 	return m.personalized, nil
 }
 
@@ -145,8 +167,47 @@ func TestAgentProvisioner_Destroy(t *testing.T) {
 
 	if len(mockAgent.deleteCalls) != 1 {
 		t.Errorf("expected 1 delete call, got %d", len(mockAgent.deleteCalls))
-	} else if mockAgent.deleteCalls[0] != "test-resource-id" {
-		t.Errorf("expected delete call for test-resource-id, got %q", mockAgent.deleteCalls[0])
+	} else if mockAgent.deleteCalls[0].id != "test-resource-id" || mockAgent.deleteCalls[0].driverType != "docker" {
+		t.Errorf("delete call = %+v, want docker/test-resource-id", mockAgent.deleteCalls[0])
+	}
+}
+
+func TestAgentProvisioner_Destroy_RejectsEmptyIDBeforeAgentCall(t *testing.T) {
+	mockAgent := newMockAgent(providersdk.Type("docker"))
+	provisioner := &AgentProvisioner{
+		Agent: mockAgent,
+		Specs: map[model.PoolName]boxyconfig.PoolSpec{
+			"test-pool": {Name: "test-pool", Type: "docker"},
+		},
+		Providers: map[string]providersdk.Instance{},
+	}
+
+	err := provisioner.Destroy(context.Background(), model.Pool{Name: "test-pool"}, model.Resource{})
+	if err == nil {
+		t.Fatal("Destroy error = nil, want empty id error")
+	}
+	if len(mockAgent.deleteCalls) != 0 {
+		t.Fatalf("deleteCalls = %v, want none", mockAgent.deleteCalls)
+	}
+}
+
+func TestAgentProvisioner_Destroy_SurfacesAgentDeleteFailure(t *testing.T) {
+	mockAgent := newMockAgent(providersdk.Type("docker"))
+	mockAgent.deleteErr = errAgentDeleteFailed
+	provisioner := &AgentProvisioner{
+		Agent: mockAgent,
+		Specs: map[model.PoolName]boxyconfig.PoolSpec{
+			"test-pool": {Name: "test-pool", Type: "docker"},
+		},
+		Providers: map[string]providersdk.Instance{},
+	}
+
+	err := provisioner.Destroy(context.Background(), model.Pool{Name: "test-pool"}, model.Resource{ID: "test-resource-id"})
+	if err == nil {
+		t.Fatal("Destroy error = nil, want agent delete failure")
+	}
+	if len(mockAgent.deleteCalls) != 1 {
+		t.Fatalf("deleteCalls = %v, want one delete attempt", mockAgent.deleteCalls)
 	}
 }
 
@@ -179,6 +240,50 @@ func TestAgentProvisioner_Allocate_PrefersTypedGuestPersonalization(t *testing.T
 	}
 	if _, ok := got["legacy"]; ok {
 		t.Fatal("expected typed guest personalization to bypass legacy allocate result")
+	}
+}
+
+func TestAgentProvisioner_Allocate_FallsBackWhenPersonalizationReturnsNil(t *testing.T) {
+	mockAgent := newMockAgent(providersdk.Type("hyperv"))
+	mockAgent.allocateResult = map[string]any{"legacy": "path"}
+	provisioner := &AgentProvisioner{
+		Agent: mockAgent,
+		Specs: map[model.PoolName]boxyconfig.PoolSpec{
+			"vm-pool": {Name: "vm-pool", Type: "vm", Provider: "hyperv-local"},
+		},
+		Providers: map[string]providersdk.Instance{
+			"hyperv-local": {Name: "hyperv-local", Type: "hyperv"},
+		},
+	}
+
+	got, err := provisioner.Allocate(context.Background(), model.Pool{Name: "vm-pool"}, model.Resource{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	if got["legacy"] != "path" {
+		t.Fatalf("Allocate result = %+v, want legacy fallback result", got)
+	}
+	if len(mockAgent.allocateCalls) != 1 || mockAgent.allocateCalls[0].driverType != "hyperv" || mockAgent.allocateCalls[0].id != "vm-1" {
+		t.Fatalf("allocateCalls = %+v, want hyperv/vm-1 fallback", mockAgent.allocateCalls)
+	}
+}
+
+func TestAgentProvisioner_Allocate_SurfacesPersonalizationFailure(t *testing.T) {
+	mockAgent := newMockAgent(providersdk.Type("hyperv"))
+	mockAgent.personalizeErr = errPersonalizeFailed
+	provisioner := &AgentProvisioner{
+		Agent: mockAgent,
+		Specs: map[model.PoolName]boxyconfig.PoolSpec{
+			"vm-pool": {Name: "vm-pool", Type: "hyperv"},
+		},
+		Providers: map[string]providersdk.Instance{},
+	}
+
+	if _, err := provisioner.Allocate(context.Background(), model.Pool{Name: "vm-pool"}, model.Resource{ID: "vm-1"}); err == nil {
+		t.Fatal("Allocate error = nil, want personalization failure")
+	}
+	if len(mockAgent.allocateCalls) != 0 {
+		t.Fatalf("allocateCalls = %+v, want no fallback after personalization failure", mockAgent.allocateCalls)
 	}
 }
 
@@ -268,5 +373,11 @@ func TestAgentProvisioner_UnknownPool(t *testing.T) {
 	_, err := provisioner.Provision(context.Background(), pool)
 	if err == nil {
 		t.Fatal("expected error for unknown pool")
+	}
+	if _, err := provisioner.Allocate(context.Background(), pool, model.Resource{ID: "res-1"}); err == nil {
+		t.Fatal("expected allocate error for unknown pool")
+	}
+	if err := provisioner.Destroy(context.Background(), pool, model.Resource{ID: "res-1"}); err == nil {
+		t.Fatal("expected destroy error for unknown pool")
 	}
 }

--- a/internal/pool/provisioner_driver_test.go
+++ b/internal/pool/provisioner_driver_test.go
@@ -1,0 +1,201 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	boxyconfig "github.com/Geogboe/boxy/internal/config"
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/providersdk"
+)
+
+type driverProvisionerConfig struct {
+	Image string `json:"image"`
+}
+
+type fakeProviderDriver struct {
+	createCfg      any
+	deleted        []string
+	allocated      []string
+	personalized   []string
+	deleteErr      error
+	personalizeErr error
+	personalize    bool
+}
+
+func (d *fakeProviderDriver) Type() providersdk.Type { return "fake" }
+
+func (d *fakeProviderDriver) Create(ctx context.Context, cfg any) (*providersdk.Resource, error) {
+	_ = ctx
+	d.createCfg = cfg
+	image, _ := cfg.(map[string]any)["image"].(string)
+	return &providersdk.Resource{
+		ID:             "provider-res-1",
+		ConnectionInfo: map[string]string{"host": "127.0.0.1"},
+		Metadata:       map[string]string{"image": image},
+	}, nil
+}
+
+func (d *fakeProviderDriver) Read(ctx context.Context, id string) (*providersdk.ResourceStatus, error) {
+	_ = ctx
+	return &providersdk.ResourceStatus{ID: id, State: "running"}, nil
+}
+
+func (d *fakeProviderDriver) Update(ctx context.Context, id string, op providersdk.Operation) (*providersdk.Result, error) {
+	_ = ctx
+	_ = id
+	_ = op
+	return &providersdk.Result{}, nil
+}
+
+func (d *fakeProviderDriver) Delete(ctx context.Context, id string) error {
+	_ = ctx
+	d.deleted = append(d.deleted, id)
+	return d.deleteErr
+}
+
+func (d *fakeProviderDriver) Allocate(ctx context.Context, id string) (map[string]any, error) {
+	_ = ctx
+	d.allocated = append(d.allocated, id)
+	return map[string]any{"allocated": id}, nil
+}
+
+func (d *fakeProviderDriver) PersonalizeGuest(ctx context.Context, id string) (*providersdk.GuestPersonalizationResult, error) {
+	_ = ctx
+	d.personalized = append(d.personalized, id)
+	if d.personalizeErr != nil {
+		return nil, d.personalizeErr
+	}
+	if !d.personalize {
+		return nil, nil
+	}
+	return &providersdk.GuestPersonalizationResult{
+		AccessDetails: providersdk.GuestAccessDetails{Properties: map[string]string{"ssh_host": "10.0.0.5"}},
+	}, nil
+}
+
+func newDriverProvisioner(t *testing.T, driver *fakeProviderDriver) *DriverProvisioner {
+	t.Helper()
+	reg := providersdk.NewRegistry()
+	if err := reg.Register(providersdk.Registration{
+		Type:        "fake",
+		ConfigProto: func() any { return &driverProvisionerConfig{} },
+		NewDriver: func(cfg any) (providersdk.Driver, error) {
+			driver.createCfg = cfg
+			return driver, nil
+		},
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return &DriverProvisioner{
+		Registry: reg,
+		Specs: map[model.PoolName]boxyconfig.PoolSpec{
+			"web": {Name: "web", Type: "container", Provider: "fake-local", Config: map[string]any{"image": "alpine"}},
+		},
+		Providers: map[string]providersdk.Instance{
+			"fake-local": {Name: "fake-local", Type: "fake"},
+		},
+		Now: func() time.Time { return time.Unix(123, 0) },
+	}
+}
+
+func TestDriverProvisioner_ProvisionMapsProviderResourceToPoolResource(t *testing.T) {
+	driver := &fakeProviderDriver{}
+	dp := newDriverProvisioner(t, driver)
+
+	res, err := dp.Provision(context.Background(), model.Pool{
+		Name: "web",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "alpine",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if res.ID != "provider-res-1" || res.OriginPool != "web" || res.Provider.Name != "fake-local" {
+		t.Fatalf("resource = %+v, want provider resource tied to web/fake-local", res)
+	}
+	if res.Type != model.ResourceTypeContainer || res.Profile != "alpine" || res.State != model.ResourceStateReady {
+		t.Fatalf("resource shape = %+v, want ready container alpine", res)
+	}
+	if res.Properties["host"] != "127.0.0.1" || res.Properties["image"] != "alpine" {
+		t.Fatalf("properties = %+v, want connection info and metadata", res.Properties)
+	}
+	if cfg, ok := driver.createCfg.(map[string]any); !ok || cfg["image"] != "alpine" {
+		t.Fatalf("driver create config = %#v, want pool image config", driver.createCfg)
+	}
+}
+
+func TestDriverProvisioner_DestroyCallsProviderDelete(t *testing.T) {
+	driver := &fakeProviderDriver{}
+	dp := newDriverProvisioner(t, driver)
+
+	err := dp.Destroy(context.Background(), model.Pool{Name: "web"}, model.Resource{ID: "provider-res-1"})
+	if err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if len(driver.deleted) != 1 || driver.deleted[0] != "provider-res-1" {
+		t.Fatalf("deleted = %v, want provider-res-1", driver.deleted)
+	}
+}
+
+func TestDriverProvisioner_DestroySurfacesProviderDeleteFailure(t *testing.T) {
+	driver := &fakeProviderDriver{deleteErr: errors.New("provider delete failed")}
+	dp := newDriverProvisioner(t, driver)
+
+	err := dp.Destroy(context.Background(), model.Pool{Name: "web"}, model.Resource{ID: "provider-res-1"})
+	if err == nil {
+		t.Fatal("Destroy error = nil, want provider failure")
+	}
+	if len(driver.deleted) != 1 {
+		t.Fatalf("deleted = %v, want one provider delete attempt", driver.deleted)
+	}
+}
+
+func TestDriverProvisioner_AllocatePrefersGuestPersonalizer(t *testing.T) {
+	driver := &fakeProviderDriver{personalize: true}
+	dp := newDriverProvisioner(t, driver)
+
+	props, err := dp.Allocate(context.Background(), model.Pool{Name: "web"}, model.Resource{ID: "provider-res-1"})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	if props["ssh_host"] != "10.0.0.5" {
+		t.Fatalf("props = %+v, want personalized access details", props)
+	}
+	if len(driver.personalized) != 1 || len(driver.allocated) != 0 {
+		t.Fatalf("personalized=%v allocated=%v, want personalizer path only", driver.personalized, driver.allocated)
+	}
+}
+
+func TestDriverProvisioner_AllocateFallsBackWhenPersonalizerHasNoResult(t *testing.T) {
+	driver := &fakeProviderDriver{}
+	dp := newDriverProvisioner(t, driver)
+
+	props, err := dp.Allocate(context.Background(), model.Pool{Name: "web"}, model.Resource{ID: "provider-res-1"})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	if props["allocated"] != "provider-res-1" {
+		t.Fatalf("props = %+v, want fallback allocation properties", props)
+	}
+	if len(driver.personalized) != 1 || len(driver.allocated) != 1 {
+		t.Fatalf("personalized=%v allocated=%v, want personalizer then fallback allocate", driver.personalized, driver.allocated)
+	}
+}
+
+func TestDriverProvisioner_DestroyRejectsEmptyResourceID(t *testing.T) {
+	driver := &fakeProviderDriver{}
+	dp := newDriverProvisioner(t, driver)
+
+	err := dp.Destroy(context.Background(), model.Pool{Name: "web"}, model.Resource{})
+	if err == nil {
+		t.Fatal("Destroy error = nil, want empty resource id error")
+	}
+	if len(driver.deleted) != 0 {
+		t.Fatalf("deleted = %v, want no provider calls", driver.deleted)
+	}
+}

--- a/internal/sandbox/deleter.go
+++ b/internal/sandbox/deleter.go
@@ -1,0 +1,110 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+type ResourceDestroyer interface {
+	DestroyResource(ctx context.Context, res model.Resource) error
+}
+
+// DeletionReconciler cleans up sandboxes that have been accepted for async
+// deletion.
+type DeletionReconciler struct {
+	store     store.Store
+	destroyer ResourceDestroyer
+}
+
+func NewDeletionReconciler(st store.Store, destroyer ResourceDestroyer) *DeletionReconciler {
+	return &DeletionReconciler{store: st, destroyer: destroyer}
+}
+
+func (r *DeletionReconciler) Reconcile(ctx context.Context) error {
+	if r == nil {
+		return fmt.Errorf("sandbox deletion reconciler is nil")
+	}
+	if r.store == nil {
+		return fmt.Errorf("store is nil")
+	}
+	if r.destroyer == nil {
+		return fmt.Errorf("resource destroyer is nil")
+	}
+
+	sandboxes, err := r.store.ListSandboxes(ctx)
+	if err != nil {
+		return fmt.Errorf("list sandboxes: %w", err)
+	}
+	sort.Slice(sandboxes, func(i, j int) bool {
+		return sandboxes[i].ID < sandboxes[j].ID
+	})
+
+	for _, sb := range sandboxes {
+		if sb.Status != model.SandboxStatusDeleting {
+			continue
+		}
+		if err := r.cleanupSandbox(ctx, sb.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *DeletionReconciler) cleanupSandbox(ctx context.Context, id model.SandboxID) error {
+	sb, err := r.store.GetSandbox(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get deleting sandbox %q: %w", id, err)
+	}
+	if sb.Status != model.SandboxStatusDeleting {
+		return nil
+	}
+
+	for len(sb.Resources) > 0 {
+		rid := sb.Resources[0]
+		res, err := r.store.GetResource(ctx, rid)
+		if errors.Is(err, store.ErrNotFound) {
+			sb.Resources = removeResourceID(sb.Resources, rid)
+			if err := r.store.PutSandbox(ctx, sb); err != nil {
+				return fmt.Errorf("remove missing resource %q from sandbox %q: %w", rid, sb.ID, err)
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("get resource %q for deleting sandbox %q: %w", rid, sb.ID, err)
+		}
+		if err := r.destroyer.DestroyResource(ctx, res); err != nil {
+			return fmt.Errorf("cleanup resource %q for sandbox %q: %w", rid, sb.ID, err)
+		}
+		sb.Resources = removeResourceID(sb.Resources, rid)
+		if err := r.store.PutSandbox(ctx, sb); err != nil {
+			return fmt.Errorf("remove destroyed resource %q from sandbox %q: %w", rid, sb.ID, err)
+		}
+	}
+
+	if err := r.store.DeleteSandbox(ctx, sb.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("delete cleaned sandbox %q: %w", sb.ID, err)
+	}
+	return nil
+}
+
+func removeResourceID(ids []model.ResourceID, id model.ResourceID) []model.ResourceID {
+	out := ids[:0]
+	for _, existing := range ids {
+		if existing == id {
+			continue
+		}
+		out = append(out, existing)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/sandbox/deleter_test.go
+++ b/internal/sandbox/deleter_test.go
@@ -1,0 +1,237 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Geogboe/boxy/internal/pool"
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+type fakeDestroyer struct {
+	destroyed []model.ResourceID
+	err       error
+	errOn     model.ResourceID
+}
+
+func (d *fakeDestroyer) DestroyResource(ctx context.Context, res model.Resource) error {
+	_ = ctx
+	d.destroyed = append(d.destroyed, res.ID)
+	if d.errOn != "" && res.ID == d.errOn {
+		return d.err
+	}
+	if d.errOn != "" {
+		return nil
+	}
+	return d.err
+}
+
+func TestDeletionReconciler_CleansResourcesAndDeletesSandbox(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{ID: "res-1", OriginPool: "web", State: model.ResourceStateAllocated}
+	if err := st.PutResource(ctx, res); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusDeleting,
+		Resources: []model.ResourceID{res.ID},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	destroyer := &fakeDestroyer{}
+	if err := NewDeletionReconciler(st, destroyer).Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(destroyer.destroyed) != 1 || destroyer.destroyed[0] != res.ID {
+		t.Fatalf("destroyed = %v, want [%s]", destroyer.destroyed, res.ID)
+	}
+	if _, err := st.GetSandbox(ctx, "sb-1"); err != store.ErrNotFound {
+		t.Fatalf("sandbox err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeletionReconciler_DestroyFailurePreservesDeletingSandboxForRetry(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{ID: "res-1", OriginPool: "web", State: model.ResourceStateAllocated}
+	if err := st.PutResource(ctx, res); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusDeleting,
+		Resources: []model.ResourceID{res.ID},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	errBoom := errors.New("boom")
+	err := NewDeletionReconciler(st, &fakeDestroyer{err: errBoom}).Reconcile(ctx)
+	if err == nil {
+		t.Fatal("expected destroy error")
+	}
+	sb, getErr := st.GetSandbox(ctx, "sb-1")
+	if getErr != nil {
+		t.Fatalf("get sandbox: %v", getErr)
+	}
+	if sb.Status != model.SandboxStatusDeleting || len(sb.Resources) != 1 || sb.Resources[0] != res.ID {
+		t.Fatalf("sandbox = %+v, want deleting with unresolved resource", sb)
+	}
+}
+
+func TestDeletionReconciler_RecordsProgressBeforeRetryableFailure(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	resources := []model.Resource{
+		{ID: "res-1", OriginPool: "web", State: model.ResourceStateAllocated},
+		{ID: "res-2", OriginPool: "web", State: model.ResourceStateAllocated},
+	}
+	for _, res := range resources {
+		if err := st.PutResource(ctx, res); err != nil {
+			t.Fatalf("put resource %q: %v", res.ID, err)
+		}
+	}
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusDeleting,
+		Resources: []model.ResourceID{"res-1", "res-2"},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	errBoom := errors.New("boom")
+	destroyer := &fakeDestroyer{err: errBoom, errOn: "res-2"}
+	err := NewDeletionReconciler(st, destroyer).Reconcile(ctx)
+	if err == nil {
+		t.Fatal("expected destroy error")
+	}
+	if len(destroyer.destroyed) != 2 {
+		t.Fatalf("destroyed = %v, want res-1 then res-2", destroyer.destroyed)
+	}
+	sb, getErr := st.GetSandbox(ctx, "sb-1")
+	if getErr != nil {
+		t.Fatalf("get sandbox: %v", getErr)
+	}
+	if sb.Status != model.SandboxStatusDeleting || len(sb.Resources) != 1 || sb.Resources[0] != "res-2" {
+		t.Fatalf("sandbox = %+v, want only failed resource left for retry", sb)
+	}
+
+	destroyer.err = nil
+	if err := NewDeletionReconciler(st, destroyer).Reconcile(ctx); err != nil {
+		t.Fatalf("retry reconcile: %v", err)
+	}
+	if _, err := st.GetSandbox(ctx, "sb-1"); err != store.ErrNotFound {
+		t.Fatalf("sandbox err = %v, want ErrNotFound", err)
+	}
+	if got, want := destroyer.destroyed, []model.ResourceID{"res-1", "res-2", "res-2"}; len(got) != len(want) {
+		t.Fatalf("destroyed = %v, want %v", got, want)
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("destroyed = %v, want %v", got, want)
+			}
+		}
+	}
+}
+
+func TestDeletionReconciler_MissingResourceRecordRemovesIDAndContinues(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusDeleting,
+		Resources: []model.ResourceID{"missing"},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	if err := NewDeletionReconciler(st, &fakeDestroyer{}).Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := st.GetSandbox(ctx, "sb-1"); err != store.ErrNotFound {
+		t.Fatalf("sandbox err = %v, want ErrNotFound", err)
+	}
+}
+
+type deletionProvisioner struct {
+	n         int
+	destroyed []model.ResourceID
+}
+
+func (p *deletionProvisioner) Provision(ctx context.Context, pl model.Pool) (model.Resource, error) {
+	_ = ctx
+	p.n++
+	return model.Resource{
+		ID:         model.ResourceID("new-ready"),
+		Type:       pl.Inventory.ExpectedType,
+		Profile:    pl.Inventory.ExpectedProfile,
+		OriginPool: pl.Name,
+		State:      model.ResourceStateReady,
+	}, nil
+}
+
+func (p *deletionProvisioner) Destroy(ctx context.Context, pl model.Pool, res model.Resource) error {
+	_ = ctx
+	_ = pl
+	p.destroyed = append(p.destroyed, res.ID)
+	return nil
+}
+
+func TestDeletionReconciler_RemovesAllocatedResourceBeforePoolReplacesIt(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	allocated := model.Resource{
+		ID:         "allocated",
+		Type:       model.ResourceTypeContainer,
+		Profile:    model.ResourceProfileDefault,
+		OriginPool: "web",
+		State:      model.ResourceStateAllocated,
+	}
+	if err := st.PutResource(ctx, allocated); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "web",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 1, MaxTotal: 1},
+		},
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusDeleting,
+		Resources: []model.ResourceID{allocated.ID},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	prov := &deletionProvisioner{}
+	poolMgr := pool.New(st, prov)
+	if err := poolMgr.Reconcile(ctx, "web"); err != nil {
+		t.Fatalf("pre-delete reconcile: %v", err)
+	}
+	if prov.n != 0 {
+		t.Fatalf("provisions before cleanup = %d, want 0", prov.n)
+	}
+
+	if err := NewDeletionReconciler(st, poolMgr).Reconcile(ctx); err != nil {
+		t.Fatalf("delete reconcile: %v", err)
+	}
+	if err := poolMgr.Reconcile(ctx, "web"); err != nil {
+		t.Fatalf("post-delete reconcile: %v", err)
+	}
+	if prov.n != 1 {
+		t.Fatalf("provisions after cleanup = %d, want 1", prov.n)
+	}
+}

--- a/internal/sandbox/fulfiller.go
+++ b/internal/sandbox/fulfiller.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -81,6 +82,9 @@ func (f *Fulfiller) reconcileSandbox(ctx context.Context, id model.SandboxID) er
 	if err != nil {
 		return fmt.Errorf("get sandbox %q: %w", id, err)
 	}
+	if sb.Status != model.SandboxStatusPending && sb.Status != model.SandboxStatusProvisioning {
+		return nil
+	}
 
 	if len(sb.Requests) == 0 {
 		return f.failSandbox(ctx, sb, "sandbox requests are required")
@@ -138,7 +142,20 @@ func (f *Fulfiller) reconcileSandbox(ctx context.Context, id model.SandboxID) er
 	}
 
 	for _, alloc := range allocations {
+		current, err := f.store.GetSandbox(ctx, sb.ID)
+		if err == store.ErrNotFound {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("get sandbox %q before allocation: %w", sb.ID, err)
+		}
+		if current.Status == model.SandboxStatusDeleting {
+			return nil
+		}
 		if _, err := f.sandboxMgr.AddFromPool(ctx, sb.ID, alloc.poolName, alloc.count); err != nil {
+			if errors.Is(err, ErrSandboxDeleting) {
+				return nil
+			}
 			return f.rollbackAllocation(ctx, snapshot, fmt.Sprintf("allocate from pool %q: %v", alloc.poolName, err))
 		}
 	}
@@ -149,6 +166,9 @@ func (f *Fulfiller) reconcileSandbox(ctx context.Context, id model.SandboxID) er
 	}
 	if err != nil {
 		return fmt.Errorf("get sandbox %q after allocation: %w", sb.ID, err)
+	}
+	if final.Status == model.SandboxStatusDeleting {
+		return nil
 	}
 	final.Status = model.SandboxStatusReady
 	final.Error = ""
@@ -215,6 +235,23 @@ func (f *Fulfiller) rollbackAllocation(ctx context.Context, snapshot allocationS
 		}
 	}
 
+	current, err := f.store.GetSandbox(ctx, snapshot.sandbox.ID)
+	if err == store.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get sandbox %q after rollback: %w", snapshot.sandbox.ID, err)
+	}
+	if current.Status == model.SandboxStatusDeleting {
+		deleting := snapshot.sandbox
+		deleting.Status = model.SandboxStatusDeleting
+		deleting.Error = current.Error
+		if err := f.store.PutSandbox(ctx, deleting); err != nil {
+			return fmt.Errorf("restore deleting sandbox %q after rollback: %w", deleting.ID, err)
+		}
+		return nil
+	}
+
 	failed := snapshot.sandbox
 	failed.Status = model.SandboxStatusFailed
 	failed.Error = msg
@@ -231,6 +268,9 @@ func (f *Fulfiller) failSandbox(ctx context.Context, sb model.Sandbox, msg strin
 	}
 	if err != nil {
 		return fmt.Errorf("get sandbox %q for failure update: %w", sb.ID, err)
+	}
+	if current.Status == model.SandboxStatusDeleting {
+		return nil
 	}
 	current.Status = model.SandboxStatusFailed
 	current.Error = msg

--- a/internal/sandbox/fulfillment_test.go
+++ b/internal/sandbox/fulfillment_test.go
@@ -38,6 +38,39 @@ type fakeFulfillProvisioner struct {
 	failPool model.PoolName
 }
 
+type deletingReadyEnsurer struct {
+	store store.Store
+}
+
+type deletingFailingReadyEnsurer struct {
+	store store.Store
+}
+
+func (e deletingReadyEnsurer) EnsureReady(ctx context.Context, poolName model.PoolName, minReady int) error {
+	_ = poolName
+	_ = minReady
+	sb, err := e.store.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		return err
+	}
+	sb.Status = model.SandboxStatusDeleting
+	return e.store.PutSandbox(ctx, sb)
+}
+
+func (e deletingFailingReadyEnsurer) EnsureReady(ctx context.Context, poolName model.PoolName, minReady int) error {
+	_ = poolName
+	_ = minReady
+	sb, err := e.store.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		return err
+	}
+	sb.Status = model.SandboxStatusDeleting
+	if err := e.store.PutSandbox(ctx, sb); err != nil {
+		return err
+	}
+	return fmt.Errorf("ensure failed after delete request")
+}
+
 func (p *fakeFulfillProvisioner) Provision(ctx context.Context, pl model.Pool) (model.Resource, error) {
 	_ = ctx
 	if pl.Name == p.failPool {
@@ -63,6 +96,27 @@ func (p *fakeFulfillProvisioner) Destroy(ctx context.Context, pool model.Pool, r
 	return nil
 }
 
+type deletingFailingAllocator struct {
+	store    store.Store
+	failPool model.PoolName
+}
+
+func (a deletingFailingAllocator) Allocate(ctx context.Context, p model.Pool, r model.Resource) (map[string]any, error) {
+	_ = r
+	if p.Name != a.failPool {
+		return map[string]any{"allocated": true}, nil
+	}
+	sb, err := a.store.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		return nil, err
+	}
+	sb.Status = model.SandboxStatusDeleting
+	if err := a.store.PutSandbox(ctx, sb); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("allocator failed after delete request")
+}
+
 func TestFulfiller_ReconcilePending_MarksSandboxReady(t *testing.T) {
 	t.Parallel()
 
@@ -78,6 +132,7 @@ func TestFulfiller_ReconcilePending_MarksSandboxReady(t *testing.T) {
 		CreatedAt: time.Unix(1, 0).UTC(),
 		UpdatedAt: time.Unix(1, 0).UTC(),
 	}
+
 	if err := st.PutResource(ctx, ready); err != nil {
 		t.Fatalf("put resource: %v", err)
 	}
@@ -126,6 +181,154 @@ func TestFulfiller_ReconcilePending_MarksSandboxReady(t *testing.T) {
 	}
 	if res.State != model.ResourceStateAllocated {
 		t.Fatalf("resource state = %q, want %q", res.State, model.ResourceStateAllocated)
+	}
+}
+
+func TestFulfiller_ReconcileDeletingSandboxDoesNotAllocate(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	ready := model.Resource{
+		ID:      "res-ready",
+		Type:    model.ResourceTypeContainer,
+		Profile: "kali",
+		State:   model.ResourceStateReady,
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusDeleting,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1}},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, pool.New(st, &fakeFulfillProvisioner{}), New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	sb, err := st.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != model.SandboxStatusDeleting || len(sb.Resources) != 0 {
+		t.Fatalf("sandbox = %+v, want deleting without resources", sb)
+	}
+	res, err := st.GetResource(ctx, ready.ID)
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	if res.State != model.ResourceStateReady {
+		t.Fatalf("resource state = %q, want ready", res.State)
+	}
+}
+
+func TestFulfiller_ReconcileStopsIfSandboxStartsDeletingAfterEnsureReady(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	ready := model.Resource{
+		ID:      "res-ready",
+		Type:    model.ResourceTypeContainer,
+		Profile: "kali",
+		State:   model.ResourceStateReady,
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+			Resources:       []model.Resource{ready},
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1}},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, deletingReadyEnsurer{store: st}, New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	sb, err := st.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != model.SandboxStatusDeleting || len(sb.Resources) != 0 {
+		t.Fatalf("sandbox = %+v, want deletion to win race before allocation", sb)
+	}
+	res, err := st.GetResource(ctx, ready.ID)
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	if res.State != model.ResourceStateReady {
+		t.Fatalf("resource state = %q, want ready", res.State)
+	}
+}
+
+func TestFulfiller_ReconcilePreservesDeletingWhenEnsureReadyFailsAfterDelete(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	if err := st.PutPool(ctx, model.Pool{
+		Name: "kali",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: "kali",
+		},
+	}); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:       "sb-1",
+		Name:     "lab",
+		Status:   model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: "kali", Count: 1}},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, deletingFailingReadyEnsurer{store: st}, New(st, fakeAllocator{}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	sb, err := st.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != model.SandboxStatusDeleting {
+		t.Fatalf("status = %q, want deleting", sb.Status)
+	}
+	if sb.Error != "" {
+		t.Fatalf("error = %q, want empty", sb.Error)
 	}
 }
 
@@ -269,6 +472,108 @@ func TestFulfiller_ReconcilePending_MarksSandboxFailedWhenNoMatchingPool(t *test
 	}
 	if len(got.Resources) != 0 {
 		t.Fatalf("resources len = %d, want 0", len(got.Resources))
+	}
+}
+
+func TestFulfiller_RollbackPreservesDeletingAndRestoresInventory(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	webRes := model.Resource{
+		ID:        "res-web",
+		Type:      model.ResourceTypeContainer,
+		Profile:   "web",
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(1, 0).UTC(),
+		UpdatedAt: time.Unix(1, 0).UTC(),
+	}
+	winRes := model.Resource{
+		ID:        "res-win",
+		Type:      model.ResourceTypeVM,
+		Profile:   "win",
+		Provider:  model.ProviderRef{Name: "fake"},
+		State:     model.ResourceStateReady,
+		CreatedAt: time.Unix(2, 0).UTC(),
+		UpdatedAt: time.Unix(2, 0).UTC(),
+	}
+	for _, res := range []model.Resource{webRes, winRes} {
+		if err := st.PutResource(ctx, res); err != nil {
+			t.Fatalf("put resource %q: %v", res.ID, err)
+		}
+	}
+	for _, pl := range []model.Pool{
+		{
+			Name: "web",
+			Inventory: model.ResourceCollection{
+				ExpectedType:    model.ResourceTypeContainer,
+				ExpectedProfile: "web",
+				Resources:       []model.Resource{webRes},
+			},
+		},
+		{
+			Name: "win",
+			Inventory: model.ResourceCollection{
+				ExpectedType:    model.ResourceTypeVM,
+				ExpectedProfile: "win",
+				Resources:       []model.Resource{winRes},
+			},
+		},
+	} {
+		if err := st.PutPool(ctx, pl); err != nil {
+			t.Fatalf("put pool %q: %v", pl.Name, err)
+		}
+	}
+
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:     "sb-1",
+		Name:   "lab",
+		Status: model.SandboxStatusPending,
+		Requests: []model.ResourceRequest{
+			{Type: model.ResourceTypeContainer, Profile: "web", Count: 1},
+			{Type: model.ResourceTypeVM, Profile: "win", Count: 1},
+		},
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	f := NewFulfiller(st, pool.New(st, &fakeFulfillProvisioner{}), New(st, deletingFailingAllocator{store: st, failPool: "win"}))
+	if err := f.Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	sb, err := st.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != model.SandboxStatusDeleting {
+		t.Fatalf("status = %q, want deleting", sb.Status)
+	}
+	if len(sb.Resources) != 0 {
+		t.Fatalf("sandbox resources = %v, want rollback to pre-allocation resources", sb.Resources)
+	}
+	for _, poolName := range []model.PoolName{"web", "win"} {
+		pl, err := st.GetPool(ctx, poolName)
+		if err != nil {
+			t.Fatalf("get pool %q: %v", poolName, err)
+		}
+		if len(pl.Inventory.Resources) != 1 {
+			t.Fatalf("pool %q inventory len = %d, want 1", poolName, len(pl.Inventory.Resources))
+		}
+		if pl.Inventory.Resources[0].State != model.ResourceStateReady {
+			t.Fatalf("pool %q resource state = %q, want ready", poolName, pl.Inventory.Resources[0].State)
+		}
+	}
+	for _, resID := range []model.ResourceID{webRes.ID, winRes.ID} {
+		res, err := st.GetResource(ctx, resID)
+		if err != nil {
+			t.Fatalf("get resource %q: %v", resID, err)
+		}
+		if res.State != model.ResourceStateReady {
+			t.Fatalf("resource %q state = %q, want ready", res.ID, res.State)
+		}
 	}
 }
 

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -2,12 +2,15 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/resourcepool"
 	"github.com/Geogboe/boxy/pkg/store"
 )
+
+var ErrSandboxDeleting = errors.New("sandbox is deleting")
 
 // Manager creates sandboxes and consumes resources from pools.
 //
@@ -86,6 +89,9 @@ func (m *Manager) AddFromPool(
 	sb, err := m.store.GetSandbox(ctx, sbID)
 	if err != nil {
 		return model.Sandbox{}, fmt.Errorf("get sandbox: %w", err)
+	}
+	if sb.Status == model.SandboxStatusDeleting {
+		return model.Sandbox{}, ErrSandboxDeleting
 	}
 
 	pool, err := m.store.GetPool(ctx, poolName)
@@ -241,6 +247,34 @@ func (m *Manager) CreateFromPool(
 		}
 	}
 
+	return sb, nil
+}
+
+// RequestDelete marks a sandbox for asynchronous deletion. Cleanup is performed
+// by the daemon reconciliation loop.
+func (m *Manager) RequestDelete(ctx context.Context, sbID model.SandboxID) (model.Sandbox, error) {
+	if m == nil {
+		return model.Sandbox{}, fmt.Errorf("sandbox manager is nil")
+	}
+	if m.store == nil {
+		return model.Sandbox{}, fmt.Errorf("store is nil")
+	}
+	if sbID == "" {
+		return model.Sandbox{}, fmt.Errorf("sandbox id is required")
+	}
+
+	sb, err := m.store.GetSandbox(ctx, sbID)
+	if err != nil {
+		return model.Sandbox{}, fmt.Errorf("get sandbox: %w", err)
+	}
+	if sb.Status == model.SandboxStatusDeleting {
+		return sb, nil
+	}
+	sb.Status = model.SandboxStatusDeleting
+	sb.Error = ""
+	if err := m.store.PutSandbox(ctx, sb); err != nil {
+		return model.Sandbox{}, fmt.Errorf("mark sandbox %q deleting: %w", sb.ID, err)
+	}
 	return sb, nil
 }
 

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -85,6 +85,7 @@ func TestManager_AddFromPool_PreservesSandboxStatusUntilCallerFinalizes(t *testi
 		State:     model.ResourceStateReady,
 		CreatedAt: time.Unix(1, 0).UTC(),
 	}
+
 	if err := st.PutResource(ctx, ready); err != nil {
 		t.Fatalf("put resource: %v", err)
 	}
@@ -127,5 +128,93 @@ func TestManager_AddFromPool_PreservesSandboxStatusUntilCallerFinalizes(t *testi
 	}
 	if len(stored.Resources) != 1 {
 		t.Fatalf("resources len = %d, want 1", len(stored.Resources))
+	}
+}
+
+func TestManager_AddFromPool_RejectsDeletingSandboxBeforeConsumingResource(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	ready := model.Resource{
+		ID:      "res-1",
+		Type:    model.ResourceTypeContainer,
+		Profile: model.ResourceProfileDefault,
+		State:   model.ResourceStateReady,
+	}
+	pool := model.Pool{
+		Name: "docker-containers",
+		Inventory: model.ResourceCollection{
+			ExpectedType:    model.ResourceTypeContainer,
+			ExpectedProfile: model.ResourceProfileDefault,
+			Resources:       []model.Resource{ready},
+		},
+	}
+	sb := model.Sandbox{
+		ID:       "sb-1",
+		Name:     "demo",
+		Status:   model.SandboxStatusDeleting,
+		Requests: []model.ResourceRequest{{Type: model.ResourceTypeContainer, Profile: model.ResourceProfileDefault, Count: 1}},
+	}
+	if err := st.PutResource(ctx, ready); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	_, err := New(st, nil).AddFromPool(ctx, sb.ID, pool.Name, 1)
+	if err != ErrSandboxDeleting {
+		t.Fatalf("AddFromPool error = %v, want ErrSandboxDeleting", err)
+	}
+
+	storedSandbox, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if len(storedSandbox.Resources) != 0 {
+		t.Fatalf("sandbox resources = %v, want empty", storedSandbox.Resources)
+	}
+	storedPool, err := st.GetPool(ctx, pool.Name)
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if len(storedPool.Inventory.Resources) != 1 || storedPool.Inventory.Resources[0].ID != ready.ID {
+		t.Fatalf("pool inventory = %+v, want ready resource still present", storedPool.Inventory.Resources)
+	}
+	storedResource, err := st.GetResource(ctx, ready.ID)
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	if storedResource.State != model.ResourceStateReady {
+		t.Fatalf("resource state = %q, want ready", storedResource.State)
+	}
+}
+
+func TestManager_RequestDelete_MarksDeletingAndIsIdempotent(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	sb := model.Sandbox{ID: "sb-1", Name: "demo", Status: model.SandboxStatusReady, Resources: []model.ResourceID{"res-1"}}
+	if err := st.CreateSandbox(ctx, sb); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	mgr := New(st, nil)
+	first, err := mgr.RequestDelete(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("RequestDelete: %v", err)
+	}
+	if first.Status != model.SandboxStatusDeleting {
+		t.Fatalf("status = %q, want deleting", first.Status)
+	}
+
+	second, err := mgr.RequestDelete(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("RequestDelete second: %v", err)
+	}
+	if second.Status != model.SandboxStatusDeleting || len(second.Resources) != 1 {
+		t.Fatalf("second sandbox = %+v, want deleting with resource", second)
 	}
 }

--- a/internal/server/api_sandboxes.go
+++ b/internal/server/api_sandboxes.go
@@ -75,17 +75,17 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	httpjson.Write(w, http.StatusAccepted, sb)
 }
 
-// handleDeleteSandbox deletes a sandbox by ID and returns 204.
+// handleDeleteSandbox accepts a sandbox deletion request and returns 202.
 func (s *Server) handleDeleteSandbox(w http.ResponseWriter, r *http.Request) {
 	id := model.SandboxID(r.PathValue("id"))
-	err := s.store.DeleteSandbox(r.Context(), id)
+	sb, err := s.sandboxMgr.RequestDelete(r.Context(), id)
 	if errors.Is(err, store.ErrNotFound) {
 		httpjson.Error(w, http.StatusNotFound, "sandbox not found")
 		return
 	}
 	if err != nil {
-		httpjson.Error(w, http.StatusInternalServerError, "failed to delete sandbox")
+		httpjson.Error(w, http.StatusInternalServerError, "failed to request sandbox deletion")
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	httpjson.Write(w, http.StatusAccepted, sb)
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -438,14 +438,45 @@ func TestAPI_DeleteSandbox_found(t *testing.T) {
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/sandboxes/sb-del", nil)
 	mux.ServeHTTP(w, r)
 
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("status = %d, want 204", w.Code)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+	var got model.Sandbox
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.ID != "sb-del" || got.Status != model.SandboxStatusDeleting {
+		t.Fatalf("sandbox = %+v, want sb-del deleting", got)
+	}
+}
+
+func TestAPI_DeleteSandbox_alreadyDeletingIsAccepted(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-del", Name: "to-delete", Status: model.SandboxStatusDeleting})
+
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/sandboxes/sb-del", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+	var got model.Sandbox
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.ID != "sb-del" || got.Status != model.SandboxStatusDeleting {
+		t.Fatalf("sandbox = %+v, want sb-del deleting", got)
 	}
 }
 
 func TestAPI_DeleteSandbox_notfound(t *testing.T) {
 	t.Parallel()
-	mux := server.NewTestMux(store.NewMemoryStore(), sandbox.New(store.NewMemoryStore(), nil), false)
+	st := store.NewMemoryStore()
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/sandboxes/nonexistent", nil)
 	mux.ServeHTTP(w, r)

--- a/internal/skills/assets/boxy-cli/SKILL.md
+++ b/internal/skills/assets/boxy-cli/SKILL.md
@@ -40,6 +40,7 @@ Core commands you will commonly use:
 - Validate config with `boxy config validate` before telling the user to run `boxy serve`.
 - Prefer `boxy serve --once` for smoke checks and `boxy serve` for daemon usage.
 - Sandbox creation is asynchronous. Use `boxy sandbox create --no-wait` if you need the request accepted quickly, then poll with `boxy sandbox get`.
+- Sandbox deletion is asynchronous. `boxy sandbox delete <id>` waits until the daemon finishes cleanup; use `--no-wait` to return after acceptance.
 - Use `boxy debug pool drain <pool>` and `boxy debug pool fill <pool>` for daemon-backed operator maintenance of unused ready pool inventory.
 - If a sandbox fails or stalls, use the diagnosis workflow instead of guessing.
 - Boxy persists daemon runtime state in `.boxy/state.json` near the active config or working directory; use that fact in diagnosis, not as the primary control interface.

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -35,7 +35,8 @@ type Agent interface {
 	// Update performs an operation on an existing resource.
 	Update(ctx context.Context, provider providersdk.Type, id string, op providersdk.Operation) (*providersdk.Result, error)
 
-	// Delete destroys a resource.
+	// Delete destroys a resource. It follows the providersdk.Driver Delete
+	// contract: deleting an already-missing provider resource is successful.
 	Delete(ctx context.Context, provider providersdk.Type, id string) error
 
 	// Allocate runs allocation-time hooks on an existing resource and returns

--- a/pkg/agentsdk/embedded_test.go
+++ b/pkg/agentsdk/embedded_test.go
@@ -87,6 +87,41 @@ func TestEmbeddedAgent_UnknownProvider(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
+
+}
+
+func TestEmbeddedAgent_UnknownProviderForEveryLifecycleMethod(t *testing.T) {
+	agent := newTestAgent(t)
+	ctx := context.Background()
+	missing := providersdk.Type("nonexistent")
+
+	if _, err := agent.Read(ctx, missing, "res-1"); err == nil {
+		t.Fatal("Read unknown provider error = nil")
+	}
+	if _, err := agent.Update(ctx, missing, "res-1", &devfactory.ExecOp{}); err == nil {
+		t.Fatal("Update unknown provider error = nil")
+	}
+	if err := agent.Delete(ctx, missing, "res-1"); err == nil {
+		t.Fatal("Delete unknown provider error = nil")
+	}
+	if _, err := agent.Allocate(ctx, missing, "res-1"); err == nil {
+		t.Fatal("Allocate unknown provider error = nil")
+	}
+	if result, err := agent.PersonalizeGuest(ctx, missing, "res-1"); err == nil || result != nil {
+		t.Fatalf("PersonalizeGuest unknown provider result=%v err=%v, want error", result, err)
+	}
+}
+
+func TestEmbeddedAgent_PersonalizeGuestReturnsNilForDriverWithoutCapability(t *testing.T) {
+	agent := newTestAgent(t)
+
+	result, err := agent.PersonalizeGuest(context.Background(), devfactory.ProviderType, "res-1")
+	if err != nil {
+		t.Fatalf("PersonalizeGuest: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("PersonalizeGuest result = %+v, want nil for driver without capability", result)
+	}
 }
 
 func TestEmbeddedAgent_DuplicateProviderType(t *testing.T) {

--- a/pkg/model/profile_request_pool_test.go
+++ b/pkg/model/profile_request_pool_test.go
@@ -1,0 +1,108 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProfileRegistryValidatesAndFindsProfiles(t *testing.T) {
+	registry, err := NewProfileRegistry([]Profile{
+		{Type: ResourceTypeContainer, Name: "alpine"},
+		{Type: ResourceTypeVM, Name: "win2025"},
+	})
+	if err != nil {
+		t.Fatalf("NewProfileRegistry: %v", err)
+	}
+	if !registry.Has(ResourceTypeContainer, "alpine") {
+		t.Fatal("registry missing container/alpine")
+	}
+	if registry.Has(ResourceTypeContainer, "win2025") {
+		t.Fatal("registry matched profile on wrong type")
+	}
+	var nilRegistry *ProfileRegistry
+	if nilRegistry.Has(ResourceTypeContainer, "alpine") {
+		t.Fatal("nil registry reported profile present")
+	}
+}
+
+func TestProfileRegistryRejectsInvalidAndDuplicateProfiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []Profile
+		want     string
+	}{
+		{name: "missing type", profiles: []Profile{{Name: "alpine"}}, want: "profile type is required"},
+		{name: "missing name", profiles: []Profile{{Type: ResourceTypeContainer}}, want: "profile name is required"},
+		{
+			name: "duplicate",
+			profiles: []Profile{
+				{Type: ResourceTypeContainer, Name: "alpine"},
+				{Type: ResourceTypeContainer, Name: "alpine"},
+			},
+			want: "duplicate profile",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewProfileRegistry(tt.profiles)
+			if err == nil {
+				t.Fatalf("NewProfileRegistry error = nil, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("NewProfileRegistry error = %q, want containing %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceRequestValidate(t *testing.T) {
+	valid := ResourceRequest{Type: ResourceTypeContainer, Profile: "alpine", Count: 1}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("Validate valid request: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		req  ResourceRequest
+		want string
+	}{
+		{name: "missing type", req: ResourceRequest{Profile: "alpine", Count: 1}, want: "request type is required"},
+		{name: "unknown type", req: ResourceRequest{Type: ResourceTypeUnknown, Profile: "alpine", Count: 1}, want: "request type is required"},
+		{name: "missing profile", req: ResourceRequest{Type: ResourceTypeContainer, Count: 1}, want: "request profile is required"},
+		{name: "zero count", req: ResourceRequest{Type: ResourceTypeContainer, Profile: "alpine"}, want: "request count must be > 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if err == nil {
+				t.Fatalf("Validate error = nil, want %q", tt.want)
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("Validate error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestPoolDrainEffective(t *testing.T) {
+	tests := []struct {
+		name  string
+		drain PoolDrainState
+		want  bool
+	}{
+		{name: "none"},
+		{name: "config", drain: PoolDrainState{ConfigDeclared: true}, want: true},
+		{name: "operator", drain: PoolDrainState{Operator: true}, want: true},
+		{name: "both", drain: PoolDrainState{ConfigDeclared: true, Operator: true}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.drain.Effective(); got != tt.want {
+				t.Fatalf("Effective() = %t, want %t", got, tt.want)
+			}
+			if got := (Pool{Drain: tt.drain}).EffectivelyDrained(); got != tt.want {
+				t.Fatalf("EffectivelyDrained() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/model/resource_collection_test.go
+++ b/pkg/model/resource_collection_test.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResourceCollectionAddEnforcesHomogeneousInventory(t *testing.T) {
+	collection := ResourceCollection{
+		ExpectedType:    ResourceTypeContainer,
+		ExpectedProfile: "alpine",
+	}
+	res := Resource{ID: "res-1", Type: ResourceTypeContainer, Profile: "alpine", State: ResourceStateReady}
+
+	if err := collection.Add(res); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(collection.Resources) != 1 || collection.Resources[0].ID != res.ID {
+		t.Fatalf("resources = %+v, want res-1", collection.Resources)
+	}
+
+	err := collection.Add(Resource{ID: "res-2", Type: ResourceTypeVM, Profile: "alpine", State: ResourceStateReady})
+	if err == nil {
+		t.Fatal("Add mismatched type error = nil")
+	}
+	if len(collection.Resources) != 1 {
+		t.Fatalf("resources len = %d, want original collection unchanged", len(collection.Resources))
+	}
+}
+
+func TestResourceCollectionAddRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *ResourceCollection
+		res  Resource
+		want string
+	}{
+		{
+			name: "nil collection",
+			c:    nil,
+			res:  Resource{ID: "res-1", Type: ResourceTypeContainer, Profile: "alpine"},
+			want: "resource collection is nil",
+		},
+		{
+			name: "missing expected type",
+			c:    &ResourceCollection{ExpectedProfile: "alpine"},
+			res:  Resource{ID: "res-1", Type: ResourceTypeContainer, Profile: "alpine"},
+			want: "pool key mismatch",
+		},
+		{
+			name: "missing resource type",
+			c:    &ResourceCollection{ExpectedType: ResourceTypeContainer, ExpectedProfile: "alpine"},
+			res:  Resource{ID: "res-1", Profile: "alpine"},
+			want: "pool key mismatch",
+		},
+		{
+			name: "missing expected profile",
+			c:    &ResourceCollection{ExpectedType: ResourceTypeContainer},
+			res:  Resource{ID: "res-1", Type: ResourceTypeContainer, Profile: "alpine"},
+			want: "expected profile",
+		},
+		{
+			name: "missing resource profile",
+			c:    &ResourceCollection{ExpectedType: ResourceTypeContainer, ExpectedProfile: "alpine"},
+			res:  Resource{ID: "res-1", Type: ResourceTypeContainer},
+			want: "resource profile",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.c.Add(tt.res)
+			if err == nil {
+				t.Fatalf("Add error = nil, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Add error = %q, want containing %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceCollectionValidateDetectsBadInventory(t *testing.T) {
+	valid := ResourceCollection{
+		ExpectedType:    ResourceTypeContainer,
+		ExpectedProfile: "alpine",
+		Resources:       []Resource{{ID: "res-1", Type: ResourceTypeContainer, Profile: "alpine"}},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("Validate valid collection: %v", err)
+	}
+
+	mismatched := valid
+	mismatched.Resources = []Resource{{ID: "res-1", Type: ResourceTypeVM, Profile: "alpine"}}
+	if err := mismatched.Validate(); err == nil {
+		t.Fatal("Validate mismatched collection error = nil")
+	}
+
+	missingProfile := valid
+	missingProfile.Resources = []Resource{{ID: "res-1", Type: ResourceTypeContainer}}
+	if err := missingProfile.Validate(); err == nil {
+		t.Fatal("Validate missing-profile collection error = nil")
+	}
+}

--- a/pkg/model/sandbox.go
+++ b/pkg/model/sandbox.go
@@ -10,6 +10,7 @@ const (
 	SandboxStatusPending      SandboxStatus = "pending"
 	SandboxStatusProvisioning SandboxStatus = "provisioning"
 	SandboxStatusReady        SandboxStatus = "ready"
+	SandboxStatusDeleting     SandboxStatus = "deleting"
 	SandboxStatusFailed       SandboxStatus = "failed"
 )
 

--- a/pkg/providersdk/driver.go
+++ b/pkg/providersdk/driver.go
@@ -32,6 +32,10 @@ type Driver interface {
 	Update(ctx context.Context, id string, op Operation) (*Result, error)
 
 	// Delete destroys a resource and cleans up associated state.
+	//
+	// Delete must be idempotent for missing provider resources: if the resource
+	// is already gone, return nil. Boxy may retry cleanup after partially
+	// completed state updates.
 	Delete(ctx context.Context, id string) error
 
 	// Allocate is called when a resource transitions from ready to allocated

--- a/pkg/providersdk/guest_personalization_test.go
+++ b/pkg/providersdk/guest_personalization_test.go
@@ -22,3 +22,35 @@ func TestResolveSecretRef_Invalid(t *testing.T) {
 		t.Fatal("expected invalid secret ref error")
 	}
 }
+
+func TestResolveSecretRef_RejectsMissingEnvAndUnsupportedKind(t *testing.T) {
+	t.Setenv("BOXY_EMPTY_SECRET_TEST", "")
+
+	tests := []SecretRef{
+		"",
+		"env:BOXY_MISSING_SECRET_TEST",
+		"env:BOXY_EMPTY_SECRET_TEST",
+		"file:path",
+	}
+	for _, ref := range tests {
+		if _, err := ResolveSecretRef(context.Background(), ref); err == nil {
+			t.Fatalf("ResolveSecretRef(%q) error = nil", ref)
+		}
+	}
+}
+
+func TestGuestAccessDetailsToProperties(t *testing.T) {
+	if props := (GuestAccessDetails{}).ToProperties(); props != nil {
+		t.Fatalf("empty ToProperties = %+v, want nil", props)
+	}
+
+	details := GuestAccessDetails{Properties: map[string]string{"ssh_host": "10.0.0.5"}}
+	props := details.ToProperties()
+	if props["ssh_host"] != "10.0.0.5" {
+		t.Fatalf("props = %+v, want ssh_host", props)
+	}
+	props["ssh_host"] = "changed"
+	if details.Properties["ssh_host"] != "10.0.0.5" {
+		t.Fatalf("ToProperties aliased source map, got %q", details.Properties["ssh_host"])
+	}
+}

--- a/pkg/providersdk/providers/devfactory/driver.go
+++ b/pkg/providersdk/providers/devfactory/driver.go
@@ -216,7 +216,7 @@ func (d *Driver) Delete(ctx context.Context, id string) error {
 	}
 
 	if _, ok := store.Resources[id]; !ok {
-		return fmt.Errorf("devfactory: resource %q not found", id)
+		return nil
 	}
 	delete(store.Resources, id)
 

--- a/pkg/providersdk/providers/devfactory/driver_test.go
+++ b/pkg/providersdk/providers/devfactory/driver_test.go
@@ -178,8 +178,8 @@ func TestDriver_Delete_NotFound(t *testing.T) {
 	d := newTestDriver(t, &Config{})
 
 	err := d.Delete(context.Background(), "nonexistent")
-	if err == nil {
-		t.Fatal("expected error for nonexistent resource")
+	if err != nil {
+		t.Fatalf("Delete missing resource: %v", err)
 	}
 }
 

--- a/pkg/providersdk/providers/docker/driver.go
+++ b/pkg/providersdk/providers/docker/driver.go
@@ -263,6 +263,9 @@ func (d *Driver) Delete(ctx context.Context, id string) error {
 		return fmt.Errorf("resource id is required")
 	}
 	if err := d.cli.ContainerRemove(ctx, id, container.RemoveOptions{Force: true}); err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("docker ContainerRemove %s: %w", id, err)
 	}
 	return nil

--- a/pkg/providersdk/providers/docker/driver_test.go
+++ b/pkg/providersdk/providers/docker/driver_test.go
@@ -432,6 +432,18 @@ func TestDriver_Delete_EmptyID(t *testing.T) {
 	}
 }
 
+func TestDriver_Delete_NotFoundIsSuccess(t *testing.T) {
+	mock := &mockDockerClient{
+		containerRemove: func(_ context.Context, _ string, _ container.RemoveOptions) error {
+			return notFoundError{msg: "not found"}
+		},
+	}
+	d := &Driver{cli: mock}
+	if err := d.Delete(context.Background(), "missing"); err != nil {
+		t.Fatalf("Delete missing container: %v", err)
+	}
+}
+
 // --- Allocate ---
 
 func TestDriver_Allocate_ReturnsExecCommand(t *testing.T) {

--- a/pkg/providersdk/providers/hyperv/driver.go
+++ b/pkg/providersdk/providers/hyperv/driver.go
@@ -276,7 +276,11 @@ func (d *Driver) Delete(ctx context.Context, id string) error {
 
 	infoScript := fmt.Sprintf(`
 $ErrorActionPreference = 'Stop'
-$vm = Get-VM -Id '%s'
+$vm = Get-VM -Id '%s' -ErrorAction SilentlyContinue
+if ($null -eq $vm) {
+  '__BOXY_NOT_FOUND__'
+  return
+}
 $vhd = (Get-VMHardDiskDrive -VMName $vm.Name | Select-Object -First 1).Path
 "$($vm.Name)|$vhd"
 `, psq(id))
@@ -284,6 +288,9 @@ $vhd = (Get-VMHardDiskDrive -VMName $vm.Name | Select-Object -First 1).Path
 	out, err := d.ps(ctx, infoScript)
 	if err != nil {
 		return fmt.Errorf("hyperv delete: get VM info for %s: %w", id, err)
+	}
+	if strings.TrimSpace(out) == "__BOXY_NOT_FOUND__" {
+		return nil
 	}
 
 	parts := strings.SplitN(strings.TrimSpace(out), "|", 2)

--- a/pkg/providersdk/providers/hyperv/driver_test.go
+++ b/pkg/providersdk/providers/hyperv/driver_test.go
@@ -326,6 +326,21 @@ func TestDriver_Delete_HappyPath(t *testing.T) {
 	}
 }
 
+func TestDriver_Delete_MissingVMIsSuccess(t *testing.T) {
+	calls := 0
+	d := mockDriver(func(_ context.Context, _ string) (string, error) {
+		calls++
+		return "__BOXY_NOT_FOUND__\n", nil
+	})
+
+	if err := d.Delete(context.Background(), fakeGUID); err != nil {
+		t.Fatalf("Delete missing VM: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("powershell calls = %d, want 1", calls)
+	}
+}
+
 // --- Allocate ---
 
 func TestDriver_Allocate_Linux(t *testing.T) {

--- a/pkg/providersdk/registry_test.go
+++ b/pkg/providersdk/registry_test.go
@@ -1,0 +1,128 @@
+package providersdk
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type registryDriver struct{}
+
+func (registryDriver) Type() Type { return "fake" }
+func (registryDriver) Create(context.Context, any) (*Resource, error) {
+	return &Resource{ID: "res-1"}, nil
+}
+func (registryDriver) Read(context.Context, string) (*ResourceStatus, error) {
+	return &ResourceStatus{}, nil
+}
+func (registryDriver) Update(context.Context, string, Operation) (*Result, error) {
+	return &Result{}, nil
+}
+func (registryDriver) Delete(context.Context, string) error { return nil }
+func (registryDriver) Allocate(context.Context, string) (map[string]any, error) {
+	return nil, nil
+}
+
+func testRegistration() Registration {
+	return Registration{
+		Type:        "fake",
+		ConfigProto: func() any { return &struct{}{} },
+		NewDriver:   func(any) (Driver, error) { return registryDriver{}, nil },
+	}
+}
+
+func TestRegistryRegisterGetAndTypes(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(testRegistration()); err != nil {
+		t.Fatalf("Register fake: %v", err)
+	}
+	if err := registry.Register(Registration{
+		Type:        "alpha",
+		ConfigProto: func() any { return &struct{}{} },
+		NewDriver:   func(any) (Driver, error) { return registryDriver{}, nil },
+	}); err != nil {
+		t.Fatalf("Register alpha: %v", err)
+	}
+
+	if _, ok := registry.Get("fake"); !ok {
+		t.Fatal("Get fake returned ok=false")
+	}
+	got := registry.Types()
+	want := []Type{"alpha", "fake"}
+	if len(got) != len(want) {
+		t.Fatalf("Types = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Types = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestRegistryRegisterRejectsInvalidRegistrations(t *testing.T) {
+	tests := []struct {
+		name string
+		reg  Registration
+		want string
+	}{
+		{name: "missing type", reg: Registration{ConfigProto: func() any { return nil }, NewDriver: func(any) (Driver, error) { return registryDriver{}, nil }}, want: "registration type is empty"},
+		{name: "missing config", reg: Registration{Type: "fake", NewDriver: func(any) (Driver, error) { return registryDriver{}, nil }}, want: "ConfigProto is nil"},
+		{name: "missing factory", reg: Registration{Type: "fake", ConfigProto: func() any { return nil }}, want: "NewDriver is nil"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewRegistry().Register(tt.reg)
+			if err == nil {
+				t.Fatalf("Register error = nil, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Register error = %q, want containing %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistryRegisterRejectsDuplicateType(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(testRegistration()); err != nil {
+		t.Fatalf("Register first: %v", err)
+	}
+	err := registry.Register(testRegistration())
+	if err == nil {
+		t.Fatal("Register duplicate error = nil")
+	}
+	if !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("Register duplicate error = %q, want duplicate message", err.Error())
+	}
+}
+
+func TestRegistryValidateInstances(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(testRegistration()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := registry.ValidateInstances(context.Background(), []Instance{{Name: "local", Type: "fake"}}); err != nil {
+		t.Fatalf("ValidateInstances known provider: %v", err)
+	}
+
+	err := registry.ValidateInstances(context.Background(), []Instance{{Name: "bad", Type: "missing"}})
+	if err == nil {
+		t.Fatal("ValidateInstances unknown error = nil")
+	}
+	if !strings.Contains(err.Error(), `provider "bad": unknown type "missing"`) {
+		t.Fatalf("ValidateInstances error = %q, want unknown provider message", err.Error())
+	}
+}
+
+func TestNilRegistryBehaviors(t *testing.T) {
+	var registry *Registry
+	if err := registry.Register(testRegistration()); err == nil {
+		t.Fatal("nil Register error = nil")
+	}
+	if _, ok := registry.Get("fake"); ok {
+		t.Fatal("nil Get ok = true")
+	}
+	if types := registry.Types(); types != nil {
+		t.Fatalf("nil Types = %v, want nil", types)
+	}
+}


### PR DESCRIPTION
## Summary
- Makes sandbox deletion asynchronous so DELETE marks sandboxes `deleting` and daemon reconciliation tears down allocated provider resources before removing the sandbox record.
- Routes cleanup through the origin pool/provider lifecycle, adds provider delete idempotency expectations, and prevents deleting sandboxes from receiving allocations.
- Removes fixed client timeouts from long-running debug pool drain/fill requests and updates CLI docs/skill guidance.

## Test plan
- `task skills:check`
- `task test`
- `task lint`
- `go test "-coverprofile=coverage.out" ./...` + `go tool cover "-func=coverage.out"` = 70.1%
- `git diff --check`
- Code review pass: no blocking issues after race fix
- PII/secrets scan completed and reviewed

## Related issues
Closes #121