### PR TITLE
fix(hyperv): guard VM teardown/provisioning against a degraded host

### DIFF
--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -56,6 +56,20 @@ func (e *ConfigDeclaredDrainError) Error() string {
 	return fmt.Sprintf("pool %q is configured drained; edit config before filling it", e.PoolName)
 }
 
+// provisionBackoffState tracks repeated provisioning failures for a pool so
+// the background reconcile loop can stop hammering a provider/host that's
+// already failing (e.g. a degraded Hyper-V host, see #118) instead of
+// retrying every tick forever.
+type provisionBackoffState struct {
+	failCount   int
+	nextAttempt time.Time
+}
+
+const (
+	provisionBackoffBase = 10 * time.Second
+	provisionBackoffMax  = 5 * time.Minute
+)
+
 // Manager reconciles a pool's inventory against its policies.
 type Manager struct {
 	store       store.Store
@@ -63,6 +77,52 @@ type Manager struct {
 	clock       Clock
 	locksMu     sync.Mutex
 	poolLocks   map[model.PoolName]*sync.Mutex
+
+	backoffMu sync.Mutex
+	backoff   map[model.PoolName]*provisionBackoffState
+}
+
+// provisionBackoffActive reports whether pool provisioning is currently in
+// a backoff window following repeated failures.
+func (m *Manager) provisionBackoffActive(poolName model.PoolName, now time.Time) bool {
+	m.backoffMu.Lock()
+	defer m.backoffMu.Unlock()
+	st := m.backoff[poolName]
+	if st == nil {
+		return false
+	}
+	return now.Before(st.nextAttempt)
+}
+
+// recordProvisionFailure increments the pool's failure count and schedules
+// the next allowed provisioning attempt using capped exponential backoff.
+func (m *Manager) recordProvisionFailure(poolName model.PoolName, now time.Time) {
+	m.backoffMu.Lock()
+	defer m.backoffMu.Unlock()
+	if m.backoff == nil {
+		m.backoff = make(map[model.PoolName]*provisionBackoffState)
+	}
+	st := m.backoff[poolName]
+	if st == nil {
+		st = &provisionBackoffState{}
+		m.backoff[poolName] = st
+	}
+	st.failCount++
+	delay := provisionBackoffBase
+	for i := 1; i < st.failCount && delay < provisionBackoffMax; i++ {
+		delay *= 2
+	}
+	if delay > provisionBackoffMax {
+		delay = provisionBackoffMax
+	}
+	st.nextAttempt = now.Add(delay)
+}
+
+// recordProvisionSuccess clears any backoff state for the pool.
+func (m *Manager) recordProvisionSuccess(poolName model.PoolName) {
+	m.backoffMu.Lock()
+	defer m.backoffMu.Unlock()
+	delete(m.backoff, poolName)
 }
 
 func New(s store.Store, p Provisioner) *Manager {
@@ -324,10 +384,7 @@ func (m *Manager) reconcileLocked(ctx context.Context, poolName model.PoolName, 
 			staleIDs := resourceIDSet(stale)
 			totalCount := countTrackedResources(p.Name, obs.resources, p.Inventory.Resources, staleIDs)
 
-			effectiveMinReady := p.Policies.Preheat.MinReady
-			if minReadyOverride > effectiveMinReady {
-				effectiveMinReady = minReadyOverride
-			}
+			effectiveMinReady := max(minReadyOverride, p.Policies.Preheat.MinReady)
 
 			if requireMinReady {
 				if capErr := maxTotalShortfall(p.Name, p.Policies.Preheat.MaxTotal, totalCount, readyCount, effectiveMinReady); capErr != nil {
@@ -336,11 +393,22 @@ func (m *Manager) reconcileLocked(ctx context.Context, poolName model.PoolName, 
 			}
 
 			toProv := computeToProvision(p, effectiveMinReady, totalCount)
+			// Background reconcile passes (requireMinReady=false) respect
+			// provisioning backoff so a failing provider/host isn't hammered
+			// every tick. Explicit EnsureReady calls always attempt, since
+			// those are user/allocation-triggered and deserve a live answer.
+			backoffActive := !requireMinReady && toProv > 0 && m.provisionBackoffActive(p.Name, obs.now)
+			if backoffActive {
+				toProv = 0
+			}
+
 			reason := "noop"
 			should := false
 			if rebuildReport.Changed || len(stale) > 0 || toProv > 0 {
 				should = true
 				reason = fmt.Sprintf("inventory_rebuilt=%t stale=%d provision=%d", rebuildReport.Changed, len(stale), toProv)
+			} else if backoffActive {
+				reason = fmt.Sprintf("provision backoff active for pool %q", p.Name)
 			}
 
 			return policycontroller.Decision[plan]{
@@ -376,8 +444,10 @@ func (m *Manager) reconcileLocked(ctx context.Context, poolName model.PoolName, 
 			for i := 0; i < pl.toProvision; i++ {
 				res, err := m.provisioner.Provision(ctx, p)
 				if err != nil {
+					m.recordProvisionFailure(p.Name, pl.now)
 					return fmt.Errorf("provision resource for pool %q: %w", p.Name, err)
 				}
+				m.recordProvisionSuccess(p.Name)
 				if res.OriginPool == "" {
 					res.OriginPool = p.Name
 				}

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -11,13 +11,19 @@ import (
 )
 
 type fakeProvisioner struct {
-	n          int
-	destroyed  []model.ResourceID
-	destroyErr error
+	n              int
+	provisionCalls int
+	provisionErr   error
+	destroyed      []model.ResourceID
+	destroyErr     error
 }
 
 func (p *fakeProvisioner) Provision(ctx context.Context, pool model.Pool) (model.Resource, error) {
 	_ = ctx
+	p.provisionCalls++
+	if p.provisionErr != nil {
+		return model.Resource{}, p.provisionErr
+	}
 	p.n++
 	return model.Resource{
 		ID:        model.ResourceID("res_" + string(rune('a'+p.n-1))),
@@ -701,6 +707,130 @@ func TestManager_Fill_ConfigDeclaredDrainStillDrainsInventory(t *testing.T) {
 	}
 	if len(updated.Inventory.Resources) != 0 {
 		t.Fatalf("inventory len = %d, want 0", len(updated.Inventory.Resources))
+	}
+}
+
+func TestManager_Reconcile_ProvisionBackoffSkipsRetryUntilWindowElapses(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	pool := model.Pool{
+		Name: "p1",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 1, MaxTotal: 5},
+		},
+		Inventory: model.ResourceCollection{ExpectedType: model.ResourceTypeContainer, ExpectedProfile: model.ResourceProfileDefault},
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{provisionErr: errors.New("New-VHD failed: VMMS degraded")}
+	mgr := New(st, prov)
+	mgr.SetClock(fixedClock{t: time.Unix(2000, 0).UTC()})
+
+	if err := mgr.Reconcile(ctx, "p1"); err == nil {
+		t.Fatal("expected first reconcile to surface provisioning failure")
+	}
+	if prov.provisionCalls != 1 {
+		t.Fatalf("provisionCalls = %d, want 1", prov.provisionCalls)
+	}
+
+	// Immediately retrying should be skipped by backoff — no new provision attempt.
+	if err := mgr.Reconcile(ctx, "p1"); err != nil {
+		t.Fatalf("second reconcile (should be a no-op skip): %v", err)
+	}
+	if prov.provisionCalls != 1 {
+		t.Fatalf("provisionCalls after immediate retry = %d, want 1 (backoff should have skipped it)", prov.provisionCalls)
+	}
+
+	// Advance the clock past the backoff window; the next reconcile should retry.
+	mgr.SetClock(fixedClock{t: time.Unix(2000, 0).Add(provisionBackoffBase + time.Second).UTC()})
+	if err := mgr.Reconcile(ctx, "p1"); err == nil {
+		t.Fatal("expected reconcile after backoff window to retry and surface the failure again")
+	}
+	if prov.provisionCalls != 2 {
+		t.Fatalf("provisionCalls after backoff window elapsed = %d, want 2", prov.provisionCalls)
+	}
+}
+
+func TestManager_ProvisionBackoff_SuccessClearsFailureState(t *testing.T) {
+	mgr := New(store.NewMemoryStore(), &fakeProvisioner{})
+	now := time.Unix(2000, 0).UTC()
+
+	mgr.recordProvisionFailure("p1", now)
+	if !mgr.provisionBackoffActive("p1", now) {
+		t.Fatal("expected backoff to be active immediately after a failure")
+	}
+
+	mgr.recordProvisionSuccess("p1")
+	if mgr.provisionBackoffActive("p1", now) {
+		t.Fatal("expected success to clear backoff state")
+	}
+
+	// A fresh failure after a reset should back off from failCount=1 again
+	// (base delay), not carry over the previous failure count into a longer
+	// accumulated delay.
+	mgr.recordProvisionFailure("p1", now)
+	if mgr.provisionBackoffActive("p1", now.Add(provisionBackoffBase+time.Second)) {
+		t.Fatal("expected backoff window to have elapsed using base delay, not an accumulated longer delay")
+	}
+}
+
+func TestManager_ProvisionBackoff_EscalatesAndCaps(t *testing.T) {
+	mgr := New(store.NewMemoryStore(), &fakeProvisioner{})
+	now := time.Unix(2000, 0).UTC()
+
+	mgr.recordProvisionFailure("p1", now) // failCount=1 -> base delay
+	if mgr.provisionBackoffActive("p1", now.Add(provisionBackoffBase+time.Second)) {
+		t.Fatal("expected first failure's backoff window to have elapsed")
+	}
+
+	mgr.recordProvisionFailure("p1", now) // failCount=2 -> 2x base delay
+	if !mgr.provisionBackoffActive("p1", now.Add(provisionBackoffBase+time.Second)) {
+		t.Fatal("expected second failure's backoff window to still be active after only base delay")
+	}
+
+	for range 10 {
+		mgr.recordProvisionFailure("p1", now)
+	}
+	if mgr.provisionBackoffActive("p1", now.Add(provisionBackoffMax+time.Second)) {
+		t.Fatal("expected backoff delay to be capped at provisionBackoffMax")
+	}
+}
+
+func TestManager_EnsureReady_IgnoresProvisionBackoff(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	pool := model.Pool{
+		Name: "p1",
+		Policies: model.PoolPolicies{
+			Preheat: model.PreheatPolicy{MinReady: 0, MaxTotal: 5},
+		},
+		Inventory: model.ResourceCollection{ExpectedType: model.ResourceTypeContainer, ExpectedProfile: model.ResourceProfileDefault},
+	}
+	if err := st.PutPool(ctx, pool); err != nil {
+		t.Fatalf("put pool: %v", err)
+	}
+
+	prov := &fakeProvisioner{provisionErr: errors.New("degraded host")}
+	mgr := New(st, prov)
+	mgr.SetClock(fixedClock{t: time.Unix(2000, 0).UTC()})
+
+	// Trigger backoff via a background-style reconcile pass.
+	if err := mgr.EnsureReady(ctx, "p1", 1); err == nil {
+		t.Fatal("expected first EnsureReady to surface provisioning failure")
+	}
+	if prov.provisionCalls != 1 {
+		t.Fatalf("provisionCalls = %d, want 1", prov.provisionCalls)
+	}
+
+	// EnsureReady is user/allocation-triggered and should always attempt,
+	// even while background reconcile would be in a backoff window.
+	if err := mgr.EnsureReady(ctx, "p1", 1); err == nil {
+		t.Fatal("expected second EnsureReady to also attempt and surface the failure")
+	}
+	if prov.provisionCalls != 2 {
+		t.Fatalf("provisionCalls = %d, want 2 (EnsureReady must not be skipped by backoff)", prov.provisionCalls)
 	}
 }
 

--- a/pkg/providersdk/providers/hyperv/driver.go
+++ b/pkg/providersdk/providers/hyperv/driver.go
@@ -3,10 +3,12 @@ package hyperv
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Geogboe/boxy/pkg/providersdk"
 	"github.com/Geogboe/boxy/pkg/psdirect"
@@ -28,6 +30,54 @@ type Driver struct {
 	// resolveSecret resolves a persisted secret reference only when guest
 	// bootstrap access is needed.
 	resolveSecret func(ctx context.Context, ref providersdk.SecretRef) (string, error)
+
+	// deleteWaitTimeout/deleteWaitInterval bound how long Delete waits for a
+	// VM stuck mid-transition (e.g. "Turning Off") to reach a terminal state
+	// before giving up. Zero values use production defaults; tests override
+	// these to avoid real sleeps. See #118.
+	deleteWaitTimeout  time.Duration
+	deleteWaitInterval time.Duration
+}
+
+// ErrVMBusy indicates a VM is stuck transitioning between power states and
+// did not settle within the wait window. Callers should treat this as a
+// signal to back off and retry later rather than forcing removal, which can
+// leave a stale vmwp.exe worker and destabilize the host's Virtual Machine
+// Management service (see #118).
+var ErrVMBusy = errors.New("hyperv: vm did not reach a terminal power state in time")
+
+const (
+	defaultDeleteWaitTimeout  = 30 * time.Second
+	defaultDeleteWaitInterval = 3 * time.Second
+
+	// vmStateNotFound is a sentinel returned by state-polling scripts when
+	// the VM has disappeared (e.g. it finished tearing down on its own).
+	vmStateNotFound = "__BOXY_NOT_FOUND__"
+)
+
+// vmTransitionalStates are Hyper-V VMState values that mean "still moving
+// between power states" — not safe to force-remove against.
+var vmTransitionalStates = map[string]bool{
+	"starting": true,
+	"stopping": true,
+	"saving":   true,
+	"pausing":  true,
+	"resuming": true,
+	"reset":    true,
+}
+
+func (d *Driver) waitTimeout() time.Duration {
+	if d.deleteWaitTimeout > 0 {
+		return d.deleteWaitTimeout
+	}
+	return defaultDeleteWaitTimeout
+}
+
+func (d *Driver) waitInterval() time.Duration {
+	if d.deleteWaitInterval > 0 {
+		return d.deleteWaitInterval
+	}
+	return defaultDeleteWaitInterval
 }
 
 // New creates a Hyper-V driver.
@@ -71,6 +121,10 @@ func (d *Driver) Create(ctx context.Context, cfg any) (*providersdk.Resource, er
 		} else {
 			guestUser = "Administrator"
 		}
+	}
+
+	if err := d.checkHostHealth(ctx); err != nil {
+		return nil, fmt.Errorf("hyperv host health check failed, refusing to provision: %w", err)
 	}
 
 	vhdDir := cc.VHDDir
@@ -268,6 +322,60 @@ func (d *Driver) execOnGuest(ctx context.Context, id string, op *ExecOp) (*provi
 
 // --- Delete ---
 
+// checkHostHealth runs a lightweight, VM-independent Hyper-V host probe
+// before attempting to provision. If VMMS is already degraded (as can
+// happen after a stuck teardown, see #118), this fails fast with a clear
+// error instead of letting New-VHD/New-VM run into the same degraded state
+// on every reconcile pass.
+func (d *Driver) checkHostHealth(ctx context.Context) error {
+	_, err := d.ps(ctx, `
+$ErrorActionPreference = 'Stop'
+Get-VMHost | Out-Null
+'OK'
+`)
+	if err != nil {
+		return fmt.Errorf("hyperv host probe (Get-VMHost) failed, VMMS may be degraded: %w", err)
+	}
+	return nil
+}
+
+// waitForTerminalVMState polls a VM's power state until it leaves the
+// transitional set (see vmTransitionalStates) or disappears entirely. It
+// never attempts to force a state change — it only observes — so a VM stuck
+// in a state like "Turning Off" cannot be pushed into a worse state by this
+// call. Returns ErrVMBusy if the VM is still transitioning when the wait
+// timeout elapses.
+func (d *Driver) waitForTerminalVMState(ctx context.Context, vmName string) (string, error) {
+	deadline := time.Now().Add(d.waitTimeout())
+	stateScript := fmt.Sprintf(`
+$vm = Get-VM -Name '%s' -ErrorAction SilentlyContinue
+if ($null -eq $vm) {
+  '%s'
+} else {
+  $vm.State.ToString()
+}
+`, psq(vmName), vmStateNotFound)
+
+	for {
+		out, err := d.ps(ctx, stateScript)
+		if err != nil {
+			return "", fmt.Errorf("check VM state: %w", err)
+		}
+		state := strings.TrimSpace(out)
+		if state == vmStateNotFound || !vmTransitionalStates[strings.ToLower(state)] {
+			return state, nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("%w (name=%q, last state=%q)", ErrVMBusy, vmName, state)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(d.waitInterval()):
+		}
+	}
+}
+
 func (d *Driver) Delete(ctx context.Context, id string) error {
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -282,28 +390,49 @@ if ($null -eq $vm) {
   return
 }
 $vhd = (Get-VMHardDiskDrive -VMName $vm.Name | Select-Object -First 1).Path
-"$($vm.Name)|$vhd"
+"$($vm.Name)|$vhd|$($vm.State)"
 `, psq(id))
 
 	out, err := d.ps(ctx, infoScript)
 	if err != nil {
 		return fmt.Errorf("hyperv delete: get VM info for %s: %w", id, err)
 	}
-	if strings.TrimSpace(out) == "__BOXY_NOT_FOUND__" {
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "__BOXY_NOT_FOUND__" {
 		return nil
 	}
 
-	parts := strings.SplitN(strings.TrimSpace(out), "|", 2)
+	parts := strings.SplitN(trimmed, "|", 3)
 	vmName := ""
 	vhdPath := ""
+	state := ""
 	if len(parts) >= 1 {
 		vmName = parts[0]
 	}
 	if len(parts) >= 2 {
 		vhdPath = parts[1]
 	}
+	if len(parts) >= 3 {
+		state = parts[2]
+	}
 	if vmName == "" {
 		return fmt.Errorf("hyperv delete: could not resolve VM name for id %s", id)
+	}
+
+	// Guard against forcing removal on a VM that's mid-transition (e.g.
+	// stuck in "Turning Off"). Blindly forcing Stop-VM/Remove-VM against
+	// such a VM is what left a stale vmwp.exe worker and destabilized VMMS
+	// in #118. Wait for it to settle first; if it never does, surface
+	// ErrVMBusy so the caller can back off instead of retrying immediately.
+	if vmTransitionalStates[strings.ToLower(state)] {
+		finalState, err := d.waitForTerminalVMState(ctx, vmName)
+		if err != nil {
+			return fmt.Errorf("hyperv delete VM %q: %w", vmName, err)
+		}
+		if finalState == vmStateNotFound {
+			// VM tore itself down while we were waiting; nothing left to do.
+			return nil
+		}
 	}
 
 	deleteScript := fmt.Sprintf(`
@@ -447,7 +576,7 @@ $ErrorActionPreference = 'Stop'
 
 func parseNotes(notes string) map[string]string {
 	m := map[string]string{}
-	for _, part := range strings.Split(notes, ";") {
+	for part := range strings.SplitSeq(notes, ";") {
 		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
 		if len(kv) == 2 {
 			m[kv[0]] = kv[1]

--- a/pkg/providersdk/providers/hyperv/driver_test.go
+++ b/pkg/providersdk/providers/hyperv/driver_test.go
@@ -2,9 +2,11 @@ package hyperv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Geogboe/boxy/pkg/providersdk"
 	"github.com/Geogboe/boxy/pkg/vmsdk"
@@ -89,12 +91,17 @@ func TestDriver_Create_CleanupOnFailure(t *testing.T) {
 	callCount := 0
 	d := mockDriver(func(_ context.Context, script string) (string, error) {
 		callCount++
-		if callCount == 1 {
+		switch callCount {
+		case 1:
+			// Host health check succeeds.
+			return "OK\n", nil
+		case 2:
 			// Main create script fails.
 			return "", fmt.Errorf("New-VHD failed")
+		default:
+			// Cleanup script succeeds.
+			return "", nil
 		}
-		// Cleanup script succeeds.
-		return "", nil
 	})
 
 	_, err := d.Create(context.Background(), &CreateConfig{
@@ -103,8 +110,29 @@ func TestDriver_Create_CleanupOnFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when create script fails")
 	}
-	if callCount < 2 {
-		t.Errorf("expected cleanup call, callCount = %d", callCount)
+	if callCount < 3 {
+		t.Errorf("expected health check + create + cleanup calls, callCount = %d", callCount)
+	}
+}
+
+func TestDriver_Create_HealthCheckFailure(t *testing.T) {
+	callCount := 0
+	d := mockDriver(func(_ context.Context, _ string) (string, error) {
+		callCount++
+		return "", fmt.Errorf("Get-VMHost failed: VMMS unavailable")
+	})
+
+	_, err := d.Create(context.Background(), &CreateConfig{
+		TemplateVHD: `C:\t.vhdx`,
+	})
+	if err == nil {
+		t.Fatal("expected error when host health check fails")
+	}
+	if !strings.Contains(err.Error(), "health check failed") {
+		t.Errorf("error %q should mention health check", err.Error())
+	}
+	if callCount != 1 {
+		t.Errorf("callCount = %d, want 1 (should not attempt create after failed health check)", callCount)
 	}
 }
 
@@ -308,8 +336,8 @@ func TestDriver_Delete_HappyPath(t *testing.T) {
 		callNum++
 		switch callNum {
 		case 1:
-			// Info query: name|vhd
-			return "boxy-abc123|C:\\VMs\\boxy-abc123.vhdx\n", nil
+			// Info query: name|vhd|state (already off, no wait needed)
+			return "boxy-abc123|C:\\VMs\\boxy-abc123.vhdx|Off\n", nil
 		case 2:
 			// Stop+Remove
 			return "", nil
@@ -323,6 +351,9 @@ func TestDriver_Delete_HappyPath(t *testing.T) {
 	err := d.Delete(context.Background(), fakeGUID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if callNum != 3 {
+		t.Fatalf("callNum = %d, want 3 (no wait loop for an already-terminal VM)", callNum)
 	}
 }
 
@@ -338,6 +369,61 @@ func TestDriver_Delete_MissingVMIsSuccess(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("powershell calls = %d, want 1", calls)
+	}
+}
+
+func TestDriver_Delete_WaitsForStuckVMThenSucceeds(t *testing.T) {
+	callNum := 0
+	d := mockDriver(func(_ context.Context, _ string) (string, error) {
+		callNum++
+		switch callNum {
+		case 1:
+			// Info query: VM is mid-teardown.
+			return "boxy-abc123|C:\\VMs\\boxy-abc123.vhdx|Stopping\n", nil
+		case 2:
+			// First state poll: still stopping.
+			return "Stopping\n", nil
+		case 3:
+			// Second state poll: now settled.
+			return "Off\n", nil
+		case 4:
+			// Stop+Remove
+			return "", nil
+		case 5:
+			// Delete VHD
+			return "", nil
+		}
+		return "", fmt.Errorf("unexpected call %d", callNum)
+	})
+	d.deleteWaitInterval = time.Millisecond
+
+	if err := d.Delete(context.Background(), fakeGUID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callNum != 5 {
+		t.Fatalf("callNum = %d, want 5", callNum)
+	}
+}
+
+func TestDriver_Delete_TimesOutOnStuckVMWithoutForcingRemoval(t *testing.T) {
+	callNum := 0
+	d := mockDriver(func(_ context.Context, _ string) (string, error) {
+		callNum++
+		if callNum == 1 {
+			return "boxy-abc123|C:\\VMs\\boxy-abc123.vhdx|Stopping\n", nil
+		}
+		// Always still stopping — never settles.
+		return "Stopping\n", nil
+	})
+	d.deleteWaitTimeout = 5 * time.Millisecond
+	d.deleteWaitInterval = time.Millisecond
+
+	err := d.Delete(context.Background(), fakeGUID)
+	if err == nil {
+		t.Fatal("expected error when VM never reaches a terminal state")
+	}
+	if !errors.Is(err, ErrVMBusy) {
+		t.Fatalf("error = %v, want wrapped ErrVMBusy", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `Delete` now waits for a VM stuck mid-transition (e.g. "Turning Off") to reach a terminal power state before touching it, instead of blindly forcing `Stop-VM`/`Remove-VM` — the latter is what left a stale `vmwp.exe` worker and destabilized VMMS in the original report.
- `Create` now runs a lightweight `Get-VMHost` probe before provisioning, so a degraded host fails fast instead of every reconcile pass hitting the same `New-VHD` failure.
- Added simple capped-exponential backoff (10s → 5m) for a pool that keeps failing to provision, so the background reconcile loop stops hammering an unhealthy host every 10s. Explicit `EnsureReady` calls bypass backoff since they're user/allocation-triggered and should always get a live answer.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./pkg/providersdk/providers/hyperv/... ./internal/pool/...` — new tests cover: fast-path delete (already terminal), wait-then-succeed, timeout-without-forcing-removal, health-check gating on create, backoff escalation/cap/reset, and that `EnsureReady` ignores backoff
- [x] Full repo `go test ./...` and `golangci-lint run ./...` pass

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)