### PR TITLE
feat: gate debug provider, clean up config, activate sandbox expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Run tests
         run: go test -race -short ./...
 
+      # debug_provider*.go (internal/cli) is only compiled with -tags devtools
+      # (see #68); run it too so that code path still has CI coverage.
+      - name: Run tests (devtools build tag)
+        run: go test -race -short -tags devtools ./internal/cli/...
+
   installer-smoke:
     name: Installer Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/internal/cli/debug.go
+++ b/internal/cli/debug.go
@@ -11,7 +11,11 @@ func newDebugCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newDebugProviderCommand())
+	// `debug provider` (internal/cli/debug_provider*.go) only exercises the
+	// devfactory reference driver in-process; it's a development tool, not a
+	// release feature, so it's built behind the `devtools` build tag and
+	// excluded from release binaries. See #68.
+	registerDevtoolsDebugCommands(cmd)
 	cmd.AddCommand(newDebugPoolCommand())
 	return cmd
 }

--- a/internal/cli/debug_devtools.go
+++ b/internal/cli/debug_devtools.go
@@ -1,0 +1,11 @@
+//go:build devtools
+
+package cli
+
+import "github.com/spf13/cobra"
+
+// registerDevtoolsDebugCommands wires development-only debug commands into
+// the `boxy debug` tree. Only compiled into `devtools`-tagged builds.
+func registerDevtoolsDebugCommands(cmd *cobra.Command) {
+	cmd.AddCommand(newDebugProviderCommand())
+}

--- a/internal/cli/debug_devtools_stub.go
+++ b/internal/cli/debug_devtools_stub.go
@@ -1,0 +1,11 @@
+//go:build !devtools
+
+package cli
+
+import "github.com/spf13/cobra"
+
+// registerDevtoolsDebugCommands is a no-op in release builds. Development-only
+// debug commands (e.g. `debug provider`, which drives the devfactory
+// reference driver directly) are only available when built with
+// `-tags devtools`. See #68.
+func registerDevtoolsDebugCommands(cmd *cobra.Command) {}

--- a/internal/cli/debug_provider.go
+++ b/internal/cli/debug_provider.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_create.go
+++ b/internal/cli/debug_provider_create.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_delete.go
+++ b/internal/cli/debug_provider_delete.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_exec.go
+++ b/internal/cli/debug_provider_exec.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_get.go
+++ b/internal/cli/debug_provider_get.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_list.go
+++ b/internal/cli/debug_provider_list.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_set_state.go
+++ b/internal/cli/debug_provider_set_state.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/debug_provider_test.go
+++ b/internal/cli/debug_provider_test.go
@@ -1,3 +1,5 @@
+//go:build devtools
+
 package cli
 
 import (

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -60,9 +60,9 @@ const starterConfig = `---
 # delete the rest, and uncomment examples as your setup grows.
 #
 # Top-level sections:
-#   - server: daemon listen address and web UI settings
+#   - server: daemon listen address and web UI settings (the HTTP API is
+#     always served alongside the UI — there is no separate api: section)
 #   - providers: named driver instances available to boxy serve
-#   - agents: remote agents the server expects to see
 #   - pools: warm resource inventories Boxy reconciles for you
 #
 # Logging is configured with CLI flags rather than boxy.yaml:
@@ -70,7 +70,7 @@ const starterConfig = `---
 
 server:
   listen: ":9090"
-  # ui: true                    # Web dashboard (default: enabled)
+  # ui: true                    # Web dashboard, served at "/" (default: enabled)
   # providers: [docker, hyperv] # Optional embedded provider type hints
 
 providers:
@@ -84,13 +84,6 @@ providers:
   # with Hyper-V available.
   # - name: hyperv-local
   #   type: hyperv
-
-agents: []
-# Uncomment and adapt entries here when distributed agent support is part of
-# your setup.
-# agents:
-#   - name: build-host
-#     providers: [docker]
 
 pools:
   # Docker/container pool example.
@@ -108,12 +101,13 @@ pools:
       #   - "8080:80"
       # cpu: "1.0"
       # memory: 512m
+    # policy: only preheat and recycle are recognized here today.
     policy:
       preheat:
-        min_ready: 1
-        max_total: 3
+        min_ready: 1 # keep this many resources ready (warm) at all times
+        max_total: 3 # hard cap on total resources for this pool
       recycle:
-        max_age: 4h
+        max_age: 4h # destroy + replace ready resources older than this
 
   # Hyper-V VM pool example.
   # Use type: vm for VM inventory, then point provider: at a Hyper-V

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -61,7 +61,6 @@ func TestRunInit_WritesComprehensiveStarterTemplate(t *testing.T) {
 
 	for _, want := range []string{
 		"providers:",
-		"agents: []",
 		"type: docker",
 		"type: vm",
 		"guest_password_ref:",

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -52,6 +52,7 @@ func newSandboxCommand() *cobra.Command {
 	cmd.AddCommand(newSandboxListCommand(serverAddr))
 	cmd.AddCommand(newSandboxGetCommand(serverAddr))
 	cmd.AddCommand(newSandboxDeleteCommand(serverAddr))
+	cmd.AddCommand(newSandboxExtendCommand(serverAddr))
 
 	return cmd
 }

--- a/internal/cli/sandbox_extend.go
+++ b/internal/cli/sandbox_extend.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/spf13/cobra"
+)
+
+type extendSandboxRequest struct {
+	Duration string `json:"duration"`
+}
+
+func newSandboxExtendCommand(serverAddr func() string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extend <id> <duration>",
+		Short: "Push a sandbox's auto-destroy expiry further out",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, durationArg := args[0], args[1]
+			if _, err := time.ParseDuration(durationArg); err != nil {
+				return fmt.Errorf("invalid duration %q: %w", durationArg, err)
+			}
+
+			client := defaultAPIClient()
+			base := apiBaseURL(serverAddr())
+
+			sb, err := postJSON[extendSandboxRequest, model.Sandbox](
+				cmd.Context(),
+				client,
+				base+"/api/v1/sandboxes/"+id+"/extend",
+				extendSandboxRequest{Duration: durationArg},
+			)
+			if err != nil {
+				var apiErr *apiError
+				if errors.As(err, &apiErr) {
+					switch apiErr.StatusCode {
+					case http.StatusNotFound:
+						return fmt.Errorf("sandbox %q not found", id)
+					case http.StatusConflict:
+						return fmt.Errorf("extend sandbox %q: %s", id, apiErr.Message)
+					}
+				}
+				return fmt.Errorf("extend sandbox %q: %w", id, err)
+			}
+
+			expiry := "no expiry"
+			if sb.ExpiresAt != nil {
+				expiry = sb.ExpiresAt.Local().Format(time.RFC3339)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "extended sandbox %s, expires at %s\n", sb.ID, expiry)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -114,6 +114,34 @@ func newSandboxTestServer(t *testing.T, listItems []model.Sandbox) *httptest.Ser
 			t.Fatalf("encode resource: %v", err)
 		}
 	})
+	mux.HandleFunc("POST /api/v1/sandboxes/{id}/extend", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		sb, ok := sandboxes[id]
+		if !ok {
+			http.Error(w, `{"error":"sandbox not found"}`, http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Duration string `json:"duration"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+			return
+		}
+		d, err := time.ParseDuration(req.Duration)
+		if err != nil {
+			http.Error(w, `{"error":"invalid duration"}`, http.StatusBadRequest)
+			return
+		}
+		base := time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC)
+		expires := base.Add(d)
+		sb.ExpiresAt = &expires
+		sandboxes[id] = sb
+		w.Header().Set("Content-Type", "application/json")
+		if err := printJSONTo(w, sb); err != nil {
+			t.Fatalf("encode sandbox extend: %v", err)
+		}
+	})
 	mux.HandleFunc("DELETE /api/v1/sandboxes/{id}", func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
 		sb, ok := sandboxes[id]
@@ -278,6 +306,73 @@ func TestSandboxDelete_not_found(t *testing.T) {
 		t.Fatal("expected error for non-existent sandbox")
 	}
 	if !strings.Contains(err.Error(), `sandbox "no-such-id" not found`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSandboxExtend_found(t *testing.T) {
+	srv := newSandboxTestServer(t, nil)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.URL, "extend", "sb-1", "15m"})
+
+	output, err := captureSandboxStdout(t, func() error {
+		return cmd.ExecuteContext(context.Background())
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(output, "extended sandbox sb-1") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestSandboxExtend_not_found(t *testing.T) {
+	srv := newSandboxTestServer(t, nil)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.URL, "extend", "no-such-id", "15m"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-existent sandbox")
+	}
+	if !strings.Contains(err.Error(), `sandbox "no-such-id" not found`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSandboxExtend_invalidDurationArgRejectedBeforeRequest(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", "http://127.0.0.1:0", "extend", "sb-1", "not-a-duration"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid duration")
+	}
+	if !strings.Contains(err.Error(), "invalid duration") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSandboxExtend_conflictSurfacesServerMessage(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/sandboxes/{id}/extend", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"sandbox has no expiry to extend"}`, http.StatusConflict)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"sandbox", "--server", srv.URL, "extend", "sb-1", "15m"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for conflict response")
+	}
+	if !strings.Contains(err.Error(), "sandbox has no expiry to extend") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,9 +22,7 @@ type Config struct {
 	Providers []providersdk.Instance `json:"providers" yaml:"providers"`
 	Pools     []PoolSpec             `json:"pools,omitempty" yaml:"pools,omitempty"`
 
-	Server ServerSpec `json:"server,omitempty" yaml:"server,omitempty"`
-
-	Agents []AgentSpec `json:"agents,omitempty" yaml:"agents,omitempty"`
+	Server ServerSpec `json:"server,omitzero" yaml:"server,omitempty"`
 }
 
 type ServerSpec struct {
@@ -40,11 +38,6 @@ type ServerSpec struct {
 // Returns true when UI is nil (unset) or explicitly true.
 func (s ServerSpec) UIEnabled() bool {
 	return s.UI == nil || *s.UI
-}
-
-type AgentSpec struct {
-	Name      string   `json:"name" yaml:"name"`
-	Providers []string `json:"providers,omitempty" yaml:"providers,omitempty"`
 }
 
 func LoadFile(path string) (Config, error) {

--- a/internal/sandbox/deleter.go
+++ b/internal/sandbox/deleter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/store"
@@ -15,14 +16,30 @@ type ResourceDestroyer interface {
 }
 
 // DeletionReconciler cleans up sandboxes that have been accepted for async
-// deletion.
+// deletion, and promotes sandboxes past their Policies.AutoDestroyAfter
+// expiry into deletion.
 type DeletionReconciler struct {
 	store     store.Store
 	destroyer ResourceDestroyer
+	clock     Clock
 }
 
 func NewDeletionReconciler(st store.Store, destroyer ResourceDestroyer) *DeletionReconciler {
-	return &DeletionReconciler{store: st, destroyer: destroyer}
+	return &DeletionReconciler{store: st, destroyer: destroyer, clock: realClock{}}
+}
+
+// SetClock overrides the reconciler's time source. Used by tests.
+func (r *DeletionReconciler) SetClock(c Clock) {
+	if c != nil {
+		r.clock = c
+	}
+}
+
+func (r *DeletionReconciler) now() time.Time {
+	if r.clock == nil {
+		return time.Now().UTC()
+	}
+	return r.clock.Now()
 }
 
 func (r *DeletionReconciler) Reconcile(ctx context.Context) error {
@@ -44,9 +61,17 @@ func (r *DeletionReconciler) Reconcile(ctx context.Context) error {
 		return sandboxes[i].ID < sandboxes[j].ID
 	})
 
+	now := r.now()
 	for _, sb := range sandboxes {
 		if sb.Status != model.SandboxStatusDeleting {
-			continue
+			if sb.ExpiresAt == nil || sb.ExpiresAt.After(now) {
+				continue
+			}
+			sb.Status = model.SandboxStatusDeleting
+			sb.Error = ""
+			if err := r.store.PutSandbox(ctx, sb); err != nil {
+				return fmt.Errorf("mark expired sandbox %q deleting: %w", sb.ID, err)
+			}
 		}
 		if err := r.cleanupSandbox(ctx, sb.ID); err != nil {
 			return err

--- a/internal/sandbox/deleter_test.go
+++ b/internal/sandbox/deleter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Geogboe/boxy/internal/pool"
 	"github.com/Geogboe/boxy/pkg/model"
@@ -181,6 +182,71 @@ func (p *deletionProvisioner) Destroy(ctx context.Context, pl model.Pool, res mo
 	_ = pl
 	p.destroyed = append(p.destroyed, res.ID)
 	return nil
+}
+
+func TestDeletionReconciler_DestroysExpiredSandbox(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{ID: "res-1", OriginPool: "web", State: model.ResourceStateAllocated}
+	if err := st.PutResource(ctx, res); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	past := time.Unix(1000, 0).UTC()
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusReady,
+		Resources: []model.ResourceID{res.ID},
+		ExpiresAt: &past,
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	rec := NewDeletionReconciler(st, &fakeDestroyer{})
+	rec.SetClock(fixedClock{t: past.Add(time.Second)})
+
+	if err := rec.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := st.GetSandbox(ctx, "sb-1"); err != store.ErrNotFound {
+		t.Fatalf("sandbox err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeletionReconciler_LeavesUnexpiredSandboxAlone(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	res := model.Resource{ID: "res-1", OriginPool: "web", State: model.ResourceStateAllocated}
+	if err := st.PutResource(ctx, res); err != nil {
+		t.Fatalf("put resource: %v", err)
+	}
+	now := time.Unix(1000, 0).UTC()
+	future := now.Add(time.Hour)
+	if err := st.CreateSandbox(ctx, model.Sandbox{
+		ID:        "sb-1",
+		Status:    model.SandboxStatusReady,
+		Resources: []model.ResourceID{res.ID},
+		ExpiresAt: &future,
+	}); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	destroyer := &fakeDestroyer{}
+	rec := NewDeletionReconciler(st, destroyer)
+	rec.SetClock(fixedClock{t: now})
+
+	if err := rec.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(destroyer.destroyed) != 0 {
+		t.Fatalf("destroyed = %v, want none", destroyer.destroyed)
+	}
+	sb, err := st.GetSandbox(ctx, "sb-1")
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != model.SandboxStatusReady {
+		t.Fatalf("status = %q, want ready", sb.Status)
+	}
 }
 
 func TestDeletionReconciler_RemovesAllocatedResourceBeforePoolReplacesIt(t *testing.T) {

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -4,13 +4,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"time"
 
 	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/resourcepool"
 	"github.com/Geogboe/boxy/pkg/store"
 )
 
-var ErrSandboxDeleting = errors.New("sandbox is deleting")
+var (
+	ErrSandboxDeleting = errors.New("sandbox is deleting")
+
+	// ErrNoExpiry is returned by RequestExtend when the sandbox has no
+	// Policies.AutoDestroyAfter-derived expiry to extend.
+	ErrNoExpiry = errors.New("sandbox has no expiry to extend (policies.auto_destroy_after not set)")
+)
+
+// Clock abstracts time so expiry computation is deterministic in tests.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
 
 // Manager creates sandboxes and consumes resources from pools.
 //
@@ -18,12 +35,44 @@ var ErrSandboxDeleting = errors.New("sandbox is deleting")
 type Manager struct {
 	store     store.Store
 	allocator SandboxAllocator
+	clock     Clock
 }
 
 // New creates a Manager. allocator may be nil — if so, allocation-time hooks
 // are skipped and resource Properties are not updated at allocation time.
 func New(s store.Store, allocator SandboxAllocator) *Manager {
-	return &Manager{store: s, allocator: allocator}
+	return &Manager{store: s, allocator: allocator, clock: realClock{}}
+}
+
+// SetClock overrides the manager's time source. Used by tests.
+func (m *Manager) SetClock(c Clock) {
+	if c != nil {
+		m.clock = c
+	}
+}
+
+func (m *Manager) now() time.Time {
+	if m.clock == nil {
+		return time.Now().UTC()
+	}
+	return m.clock.Now()
+}
+
+// expiresAt computes an absolute expiry from policies.AutoDestroyAfter,
+// relative to now. Returns nil (no expiry) if the policy is unset.
+func (m *Manager) expiresAt(policies model.SandboxPolicies) (*time.Time, error) {
+	if policies.AutoDestroyAfter == "" {
+		return nil, nil
+	}
+	d, err := time.ParseDuration(policies.AutoDestroyAfter)
+	if err != nil {
+		return nil, fmt.Errorf("policies.auto_destroy_after %q: %w", policies.AutoDestroyAfter, err)
+	}
+	if d <= 0 {
+		return nil, fmt.Errorf("policies.auto_destroy_after %q must be positive", policies.AutoDestroyAfter)
+	}
+	t := m.now().Add(d)
+	return &t, nil
 }
 
 // Create creates an empty sandbox request.
@@ -48,12 +97,17 @@ func (m *Manager) CreateRequested(
 	if err != nil {
 		return model.Sandbox{}, fmt.Errorf("new sandbox id: %w", err)
 	}
+	expiresAt, err := m.expiresAt(policies)
+	if err != nil {
+		return model.Sandbox{}, err
+	}
 	sb := model.Sandbox{
-		ID:       sbID,
-		Name:     sbName,
-		Policies: policies,
-		Status:   model.SandboxStatusPending,
-		Requests: append([]model.ResourceRequest(nil), requests...),
+		ID:        sbID,
+		Name:      sbName,
+		Policies:  policies,
+		Status:    model.SandboxStatusPending,
+		Requests:  append([]model.ResourceRequest(nil), requests...),
+		ExpiresAt: expiresAt,
 	}
 	if err := m.store.CreateSandbox(ctx, sb); err != nil {
 		return model.Sandbox{}, fmt.Errorf("create sandbox: %w", err)
@@ -131,9 +185,7 @@ func (m *Manager) AddFromPool(
 				if res.Properties == nil {
 					res.Properties = make(map[string]any)
 				}
-				for k, v := range extra {
-					res.Properties[k] = v
-				}
+				maps.Copy(res.Properties, extra)
 			}
 		}
 		res.State = model.ResourceStateAllocated
@@ -207,6 +259,10 @@ func (m *Manager) CreateFromPool(
 	if err != nil {
 		return model.Sandbox{}, fmt.Errorf("new sandbox id: %w", err)
 	}
+	expiresAt, err := m.expiresAt(policies)
+	if err != nil {
+		return model.Sandbox{}, err
+	}
 
 	sb := model.Sandbox{
 		ID:        sbID,
@@ -214,6 +270,7 @@ func (m *Manager) CreateFromPool(
 		Policies:  policies,
 		Status:    model.SandboxStatusReady,
 		Resources: resourceIDs(selected),
+		ExpiresAt: expiresAt,
 	}
 	if err := m.store.CreateSandbox(ctx, sb); err != nil {
 		return model.Sandbox{}, fmt.Errorf("create sandbox: %w", err)
@@ -236,9 +293,7 @@ func (m *Manager) CreateFromPool(
 				if res.Properties == nil {
 					res.Properties = make(map[string]any)
 				}
-				for k, v := range extra {
-					res.Properties[k] = v
-				}
+				maps.Copy(res.Properties, extra)
 			}
 		}
 		res.State = model.ResourceStateAllocated
@@ -274,6 +329,44 @@ func (m *Manager) RequestDelete(ctx context.Context, sbID model.SandboxID) (mode
 	sb.Error = ""
 	if err := m.store.PutSandbox(ctx, sb); err != nil {
 		return model.Sandbox{}, fmt.Errorf("mark sandbox %q deleting: %w", sb.ID, err)
+	}
+	return sb, nil
+}
+
+// RequestExtend pushes a sandbox's automatic-expiry deadline further out by
+// extension, measured from its current expiry (not from now), so extending
+// twice compounds rather than resetting the clock. Fails if the sandbox has
+// no expiry to extend (Policies.AutoDestroyAfter was never set) or is
+// already being deleted.
+func (m *Manager) RequestExtend(ctx context.Context, sbID model.SandboxID, extension time.Duration) (model.Sandbox, error) {
+	if m == nil {
+		return model.Sandbox{}, fmt.Errorf("sandbox manager is nil")
+	}
+	if m.store == nil {
+		return model.Sandbox{}, fmt.Errorf("store is nil")
+	}
+	if sbID == "" {
+		return model.Sandbox{}, fmt.Errorf("sandbox id is required")
+	}
+	if extension <= 0 {
+		return model.Sandbox{}, fmt.Errorf("extension duration must be positive")
+	}
+
+	sb, err := m.store.GetSandbox(ctx, sbID)
+	if err != nil {
+		return model.Sandbox{}, fmt.Errorf("get sandbox: %w", err)
+	}
+	if sb.Status == model.SandboxStatusDeleting {
+		return model.Sandbox{}, ErrSandboxDeleting
+	}
+	if sb.ExpiresAt == nil {
+		return model.Sandbox{}, ErrNoExpiry
+	}
+
+	newExpiry := sb.ExpiresAt.Add(extension)
+	sb.ExpiresAt = &newExpiry
+	if err := m.store.PutSandbox(ctx, sb); err != nil {
+		return model.Sandbox{}, fmt.Errorf("extend sandbox %q: %w", sb.ID, err)
 	}
 	return sb, nil
 }

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -193,6 +193,156 @@ func TestManager_AddFromPool_RejectsDeletingSandboxBeforeConsumingResource(t *te
 	}
 }
 
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+func TestManager_CreateRequested_ComputesExpiryFromAutoDestroyAfter(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	mgr := New(st, nil)
+	now := time.Unix(1000, 0).UTC()
+	mgr.SetClock(fixedClock{t: now})
+
+	sb, err := mgr.CreateRequested(ctx, "demo", model.SandboxPolicies{AutoDestroyAfter: "30m"}, nil)
+	if err != nil {
+		t.Fatalf("CreateRequested: %v", err)
+	}
+	if sb.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to be set")
+	}
+	want := now.Add(30 * time.Minute)
+	if !sb.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %v, want %v", sb.ExpiresAt, want)
+	}
+
+	stored, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if stored.ExpiresAt == nil || !stored.ExpiresAt.Equal(want) {
+		t.Fatalf("stored ExpiresAt = %v, want %v", stored.ExpiresAt, want)
+	}
+}
+
+func TestManager_CreateRequested_NoAutoDestroyAfterMeansNoExpiry(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	sb, err := New(st, nil).CreateRequested(ctx, "demo", model.SandboxPolicies{}, nil)
+	if err != nil {
+		t.Fatalf("CreateRequested: %v", err)
+	}
+	if sb.ExpiresAt != nil {
+		t.Fatalf("ExpiresAt = %v, want nil", sb.ExpiresAt)
+	}
+}
+
+func TestManager_CreateRequested_RejectsInvalidAutoDestroyAfter(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	_, err := New(st, nil).CreateRequested(ctx, "demo", model.SandboxPolicies{AutoDestroyAfter: "not-a-duration"}, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid auto_destroy_after")
+	}
+}
+
+func TestManager_CreateRequested_RejectsNonPositiveAutoDestroyAfter(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	_, err := New(st, nil).CreateRequested(ctx, "demo", model.SandboxPolicies{AutoDestroyAfter: "-5m"}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-positive auto_destroy_after")
+	}
+}
+
+func TestManager_RequestExtend_PushesExpiryFromCurrentDeadline(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	mgr := New(st, nil)
+	now := time.Unix(1000, 0).UTC()
+	mgr.SetClock(fixedClock{t: now})
+
+	sb, err := mgr.CreateRequested(ctx, "demo", model.SandboxPolicies{AutoDestroyAfter: "10m"}, nil)
+	if err != nil {
+		t.Fatalf("CreateRequested: %v", err)
+	}
+	originalExpiry := *sb.ExpiresAt
+
+	extended, err := mgr.RequestExtend(ctx, sb.ID, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("RequestExtend: %v", err)
+	}
+	want := originalExpiry.Add(15 * time.Minute)
+	if extended.ExpiresAt == nil || !extended.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %v, want %v", extended.ExpiresAt, want)
+	}
+
+	stored, err := st.GetSandbox(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if stored.ExpiresAt == nil || !stored.ExpiresAt.Equal(want) {
+		t.Fatalf("stored ExpiresAt = %v, want %v", stored.ExpiresAt, want)
+	}
+}
+
+func TestManager_RequestExtend_FailsWithoutExistingExpiry(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	sb, err := New(st, nil).CreateRequested(ctx, "demo", model.SandboxPolicies{}, nil)
+	if err != nil {
+		t.Fatalf("CreateRequested: %v", err)
+	}
+
+	_, err = New(st, nil).RequestExtend(ctx, sb.ID, 10*time.Minute)
+	if err != ErrNoExpiry {
+		t.Fatalf("RequestExtend error = %v, want ErrNoExpiry", err)
+	}
+}
+
+func TestManager_RequestExtend_RejectsDeletingSandbox(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	mgr := New(st, nil)
+	sb, err := mgr.CreateRequested(ctx, "demo", model.SandboxPolicies{AutoDestroyAfter: "10m"}, nil)
+	if err != nil {
+		t.Fatalf("CreateRequested: %v", err)
+	}
+	if _, err := mgr.RequestDelete(ctx, sb.ID); err != nil {
+		t.Fatalf("RequestDelete: %v", err)
+	}
+
+	_, err = mgr.RequestExtend(ctx, sb.ID, 10*time.Minute)
+	if err != ErrSandboxDeleting {
+		t.Fatalf("RequestExtend error = %v, want ErrSandboxDeleting", err)
+	}
+}
+
+func TestManager_RequestExtend_RejectsNonPositiveExtension(t *testing.T) {
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+
+	mgr := New(st, nil)
+	sb, err := mgr.CreateRequested(ctx, "demo", model.SandboxPolicies{AutoDestroyAfter: "10m"}, nil)
+	if err != nil {
+		t.Fatalf("CreateRequested: %v", err)
+	}
+
+	if _, err := mgr.RequestExtend(ctx, sb.ID, 0); err == nil {
+		t.Fatal("expected error for zero extension")
+	}
+	if _, err := mgr.RequestExtend(ctx, sb.ID, -time.Minute); err == nil {
+		t.Fatal("expected error for negative extension")
+	}
+}
+
 func TestManager_RequestDelete_MarksDeletingAndIsIdempotent(t *testing.T) {
 	st := store.NewMemoryStore()
 	ctx := context.Background()

--- a/internal/server/api_pools.go
+++ b/internal/server/api_pools.go
@@ -22,6 +22,7 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/sandboxes/{id}", s.handleGetSandbox)
 	mux.HandleFunc("POST /api/v1/sandboxes", s.handleCreateSandbox)
 	mux.HandleFunc("DELETE /api/v1/sandboxes/{id}", s.handleDeleteSandbox)
+	mux.HandleFunc("POST /api/v1/sandboxes/{id}/extend", s.handleExtendSandbox)
 }
 
 // handleListPools returns all pools as JSON.

--- a/internal/server/api_sandboxes.go
+++ b/internal/server/api_sandboxes.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/Geogboe/boxy/internal/sandbox"
 	"github.com/Geogboe/boxy/pkg/httpjson"
 	"github.com/Geogboe/boxy/pkg/model"
 	"github.com/Geogboe/boxy/pkg/store"
@@ -39,7 +41,7 @@ func (s *Server) handleGetSandbox(w http.ResponseWriter, r *http.Request) {
 // createSandboxRequest is the request body for POST /api/v1/sandboxes.
 type createSandboxRequest struct {
 	Name     string                  `json:"name"`
-	Policies model.SandboxPolicies   `json:"policies,omitempty"`
+	Policies model.SandboxPolicies   `json:"policies"`
 	Requests []model.ResourceRequest `json:"requests"`
 }
 
@@ -88,4 +90,43 @@ func (s *Server) handleDeleteSandbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpjson.Write(w, http.StatusAccepted, sb)
+}
+
+// extendSandboxRequest is the request body for POST /api/v1/sandboxes/{id}/extend.
+type extendSandboxRequest struct {
+	// Duration is a Go duration string (e.g. "15m", "1h") to push the
+	// sandbox's expiry out by, measured from its current expiry.
+	Duration string `json:"duration"`
+}
+
+// handleExtendSandbox pushes a sandbox's auto-destroy expiry further out.
+// Fails with 409 if the sandbox has no expiry to extend (its policy never
+// set auto_destroy_after) or is already being deleted.
+func (s *Server) handleExtendSandbox(w http.ResponseWriter, r *http.Request) {
+	id := model.SandboxID(r.PathValue("id"))
+
+	var req extendSandboxRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		httpjson.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	extension, err := time.ParseDuration(req.Duration)
+	if err != nil || extension <= 0 {
+		httpjson.Error(w, http.StatusBadRequest, "duration must be a positive Go duration string (e.g. \"15m\")")
+		return
+	}
+
+	sb, err := s.sandboxMgr.RequestExtend(r.Context(), id, extension)
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		httpjson.Error(w, http.StatusNotFound, "sandbox not found")
+	case errors.Is(err, sandbox.ErrSandboxDeleting), errors.Is(err, sandbox.ErrNoExpiry):
+		httpjson.Error(w, http.StatusConflict, err.Error())
+	case err != nil:
+		httpjson.Error(w, http.StatusInternalServerError, "failed to extend sandbox")
+	default:
+		httpjson.Write(w, http.StatusOK, sb)
+	}
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Geogboe/boxy/internal/pool"
 	"github.com/Geogboe/boxy/internal/sandbox"
@@ -483,6 +484,106 @@ func TestAPI_DeleteSandbox_notfound(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestAPI_ExtendSandbox_pushesExpiryOut(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	original := time.Unix(1000, 0).UTC()
+	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-1", Name: "to-extend", Status: model.SandboxStatusReady, ExpiresAt: &original})
+
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+	body := bytes.NewBufferString(`{"duration":"15m"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/sb-1/extend", body)
+	r.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var got model.Sandbox
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := original.Add(15 * time.Minute)
+	if got.ExpiresAt == nil || !got.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestAPI_ExtendSandbox_notFound(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+	body := bytes.NewBufferString(`{"duration":"15m"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/nonexistent/extend", body)
+	r.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_ExtendSandbox_noExpiryIsConflict(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-1", Name: "no-expiry", Status: model.SandboxStatusReady})
+
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+	body := bytes.NewBufferString(`{"duration":"15m"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/sb-1/extend", body)
+	r.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_ExtendSandbox_deletingIsConflict(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	expiry := time.Unix(1000, 0).UTC()
+	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-1", Name: "deleting", Status: model.SandboxStatusDeleting, ExpiresAt: &expiry})
+
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+	body := bytes.NewBufferString(`{"duration":"15m"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/sb-1/extend", body)
+	r.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_ExtendSandbox_invalidDuration(t *testing.T) {
+	t.Parallel()
+	st := store.NewMemoryStore()
+	ctx := context.Background()
+	expiry := time.Unix(1000, 0).UTC()
+	_ = st.CreateSandbox(ctx, model.Sandbox{ID: "sb-1", Name: "to-extend", Status: model.SandboxStatusReady, ExpiresAt: &expiry})
+
+	mux := server.NewTestMux(st, sandbox.New(st, nil), false)
+	for _, duration := range []string{"not-a-duration", "-15m", "0m", ""} {
+		body := bytes.NewBufferString(`{"duration":"` + duration + `"}`)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/sandboxes/sb-1/extend", body)
+		r.Header.Set("Content-Type", "application/json")
+		mux.ServeHTTP(w, r)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("duration %q: status = %d, want 400; body: %s", duration, w.Code, w.Body.String())
+		}
 	}
 }
 

--- a/internal/skills/assets/boxy-cli/SKILL.md
+++ b/internal/skills/assets/boxy-cli/SKILL.md
@@ -22,6 +22,7 @@ Core commands you will commonly use:
 - `boxy sandbox list`
 - `boxy sandbox get`
 - `boxy sandbox delete`
+- `boxy sandbox extend`
 - `boxy status`
 - `boxy debug pool drain`
 - `boxy debug pool fill`
@@ -41,6 +42,7 @@ Core commands you will commonly use:
 - Prefer `boxy serve --once` for smoke checks and `boxy serve` for daemon usage.
 - Sandbox creation is asynchronous. Use `boxy sandbox create --no-wait` if you need the request accepted quickly, then poll with `boxy sandbox get`.
 - Sandbox deletion is asynchronous. `boxy sandbox delete <id>` waits until the daemon finishes cleanup; use `--no-wait` to return after acceptance.
+- `boxy sandbox extend <id> <duration>` only works on sandboxes created with `policies.auto_destroy_after` set; it pushes that expiry out by `<duration>` and fails if the sandbox has no expiry to extend or is already being deleted.
 - Use `boxy debug pool drain <pool>` and `boxy debug pool fill <pool>` for daemon-backed operator maintenance of unused ready pool inventory.
 - If a sandbox fails or stalls, use the diagnosis workflow instead of guessing.
 - Boxy persists daemon runtime state in `.boxy/state.json` near the active config or working directory; use that fact in diagnosis, not as the primary control interface.

--- a/pkg/model/sandbox.go
+++ b/pkg/model/sandbox.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 // SandboxID is a stable identifier for a sandbox (user-facing handle).
 type SandboxID string
 
@@ -23,7 +25,7 @@ type Sandbox struct {
 	Name string    `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// Policies are sandbox-level behavioral controls (security, retention, etc).
-	Policies SandboxPolicies `json:"policies,omitempty" yaml:"policies,omitempty"`
+	Policies SandboxPolicies `json:"policies,omitzero" yaml:"policies,omitempty"`
 
 	// Status is the async lifecycle state of the sandbox request.
 	Status SandboxStatus `json:"status,omitempty" yaml:"status,omitempty"`
@@ -36,6 +38,11 @@ type Sandbox struct {
 
 	// Resources are the resources that make up this sandbox.
 	Resources []ResourceID `json:"resources,omitempty" yaml:"resources,omitempty"`
+
+	// ExpiresAt is the absolute time this sandbox should be automatically
+	// destroyed, computed from Policies.AutoDestroyAfter at creation time.
+	// Nil means no automatic expiry.
+	ExpiresAt *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 }
 
 // SandboxPolicies captures sandbox-level behavior without prescribing a specific


### PR DESCRIPTION
## Summary

**#68 — debug provider cleanup**
- `debug pool drain/fill` already used the HTTP API (nothing to do there).
- `debug provider *` (only ever drove the fake `devfactory` reference driver, not real infra) is now gated behind a `devtools` build tag and excluded from release binaries. CI runs its tests with `-tags devtools` to keep coverage.

**#35 — config cleanup**
- Removed dead `Config.Agents`/`AgentSpec` (defined but never read anywhere except the init template and tests — the pull-model agent code this was for doesn't exist in this codebase).
- Polished the `boxy init` starter template accordingly and clarified that `policy:` only accepts `preheat`/`recycle` today.

**#34 — sandbox auto-expiry (the one real gap left in that issue)**
- `Policies.AutoDestroyAfter` was defined but never enforced anywhere. Sandbox creation now computes a real `ExpiresAt`, and the existing async-deletion reconciler (already ticked every 10s by the daemon) promotes expired sandboxes into deletion — no new background loop needed.
- Added `POST /api/v1/sandboxes/{id}/extend` and `boxy sandbox extend <id> <duration>` to push a sandbox's expiry out (compounds from the current deadline, not from now).
- **Behavior change to flag in release notes**: anyone with `auto_destroy_after` already set, expecting it to be a no-op, will now have sandboxes actually expire.

## Test plan
- [x] `go build ./...` and `go build -tags devtools ./...`
- [x] Verified `boxy debug provider` is present in a `-tags devtools` build and absent from a default build
- [x] `go test ./...` (both build tag variants) and `golangci-lint run ./...` pass
- [x] New tests: build-tag gating, init template drift, expiry computation/validation, extend (success/conflict/not-found/invalid-duration) at both the manager and HTTP API layer, CLI extend command

Fixes #68, Fixes #35, Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)