### PR TITLE
chore: ignore .scratch/ local temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ vite.config.ts.timestamp-*
 *.env
 
 .codex
+
+# Local scratch/temp files
+.scratch/


### PR DESCRIPTION
## Summary
- Adds `.scratch/` to `.gitignore` for repo-local temp files (used in place of `/tmp` for scratch work during sessions)

## Test plan
- N/A, gitignore-only change