### PR TITLE
feat(#133): List plumbing for post-reconnect reconciliation

### DIFF
--- a/pkg/agentproto/boxyagent/v1/agent.pb.go
+++ b/pkg/agentproto/boxyagent/v1/agent.pb.go
@@ -262,6 +262,7 @@ type CommandResult struct {
 	//	*CommandResult_Deleted
 	//	*CommandResult_Allocate
 	//	*CommandResult_Error
+	//	*CommandResult_List
 	Outcome       isCommandResult_Outcome `protobuf_oneof:"outcome"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -365,6 +366,15 @@ func (x *CommandResult) GetError() *AgentError {
 	return nil
 }
 
+func (x *CommandResult) GetList() *ListResult {
+	if x != nil {
+		if x, ok := x.Outcome.(*CommandResult_List); ok {
+			return x.List
+		}
+	}
+	return nil
+}
+
 type isCommandResult_Outcome interface {
 	isCommandResult_Outcome()
 }
@@ -393,6 +403,10 @@ type CommandResult_Error struct {
 	Error *AgentError `protobuf:"bytes,7,opt,name=error,proto3,oneof"`
 }
 
+type CommandResult_List struct {
+	List *ListResult `protobuf:"bytes,8,opt,name=list,proto3,oneof"`
+}
+
 func (*CommandResult_Resource) isCommandResult_Outcome() {}
 
 func (*CommandResult_Status) isCommandResult_Outcome() {}
@@ -404,6 +418,8 @@ func (*CommandResult_Deleted) isCommandResult_Outcome() {}
 func (*CommandResult_Allocate) isCommandResult_Outcome() {}
 
 func (*CommandResult_Error) isCommandResult_Outcome() {}
+
+func (*CommandResult_List) isCommandResult_Outcome() {}
 
 type AgentError struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -623,6 +639,7 @@ type Command struct {
 	//	*Command_Update
 	//	*Command_Delete
 	//	*Command_Allocate
+	//	*Command_List
 	Op            isCommand_Op `protobuf_oneof:"op"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -724,6 +741,15 @@ func (x *Command) GetAllocate() *AllocateCommand {
 	return nil
 }
 
+func (x *Command) GetList() *ListCommand {
+	if x != nil {
+		if x, ok := x.Op.(*Command_List); ok {
+			return x.List
+		}
+	}
+	return nil
+}
+
 type isCommand_Op interface {
 	isCommand_Op()
 }
@@ -748,6 +774,10 @@ type Command_Allocate struct {
 	Allocate *AllocateCommand `protobuf:"bytes,7,opt,name=allocate,proto3,oneof"`
 }
 
+type Command_List struct {
+	List *ListCommand `protobuf:"bytes,8,opt,name=list,proto3,oneof"`
+}
+
 func (*Command_Create) isCommand_Op() {}
 
 func (*Command_Read) isCommand_Op() {}
@@ -757,6 +787,8 @@ func (*Command_Update) isCommand_Op() {}
 func (*Command_Delete) isCommand_Op() {}
 
 func (*Command_Allocate) isCommand_Op() {}
+
+func (*Command_List) isCommand_Op() {}
 
 // config_json/operation_json carry providersdk.Driver's `cfg any` /
 // `Operation interface{}` across the wire as opaque, already-JSON-encoded
@@ -991,6 +1023,45 @@ func (x *AllocateCommand) GetResourceId() string {
 	return ""
 }
 
+// ListCommand requests every resource the driver currently manages for
+// provider_type. It carries no fields of its own — enumeration is
+// unconditional, unlike the other commands which target one resource_id.
+type ListCommand struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCommand) Reset() {
+	*x = ListCommand{}
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCommand) ProtoMessage() {}
+
+func (x *ListCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCommand.ProtoReflect.Descriptor instead.
+func (*ListCommand) Descriptor() ([]byte, []int) {
+	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{13}
+}
+
 type ResourceResult struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1002,7 +1073,7 @@ type ResourceResult struct {
 
 func (x *ResourceResult) Reset() {
 	*x = ResourceResult{}
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[13]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1014,7 +1085,7 @@ func (x *ResourceResult) String() string {
 func (*ResourceResult) ProtoMessage() {}
 
 func (x *ResourceResult) ProtoReflect() protoreflect.Message {
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[13]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1027,7 +1098,7 @@ func (x *ResourceResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceResult.ProtoReflect.Descriptor instead.
 func (*ResourceResult) Descriptor() ([]byte, []int) {
-	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{13}
+	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ResourceResult) GetId() string {
@@ -1061,7 +1132,7 @@ type ResourceStatusResult struct {
 
 func (x *ResourceStatusResult) Reset() {
 	*x = ResourceStatusResult{}
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[14]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1073,7 +1144,7 @@ func (x *ResourceStatusResult) String() string {
 func (*ResourceStatusResult) ProtoMessage() {}
 
 func (x *ResourceStatusResult) ProtoReflect() protoreflect.Message {
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[14]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1086,7 +1157,7 @@ func (x *ResourceStatusResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceStatusResult.ProtoReflect.Descriptor instead.
 func (*ResourceStatusResult) Descriptor() ([]byte, []int) {
-	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{14}
+	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ResourceStatusResult) GetId() string {
@@ -1112,7 +1183,7 @@ type OperationResult struct {
 
 func (x *OperationResult) Reset() {
 	*x = OperationResult{}
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[15]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1124,7 +1195,7 @@ func (x *OperationResult) String() string {
 func (*OperationResult) ProtoMessage() {}
 
 func (x *OperationResult) ProtoReflect() protoreflect.Message {
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[15]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1137,7 +1208,7 @@ func (x *OperationResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationResult.ProtoReflect.Descriptor instead.
 func (*OperationResult) Descriptor() ([]byte, []int) {
-	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{15}
+	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *OperationResult) GetOutputs() map[string]string {
@@ -1162,7 +1233,7 @@ type AllocateResult struct {
 
 func (x *AllocateResult) Reset() {
 	*x = AllocateResult{}
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[16]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1174,7 +1245,7 @@ func (x *AllocateResult) String() string {
 func (*AllocateResult) ProtoMessage() {}
 
 func (x *AllocateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_boxyagent_v1_agent_proto_msgTypes[16]
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1187,12 +1258,56 @@ func (x *AllocateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AllocateResult.ProtoReflect.Descriptor instead.
 func (*AllocateResult) Descriptor() ([]byte, []int) {
-	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{16}
+	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *AllocateResult) GetPropertiesJson() []byte {
 	if x != nil {
 		return x.PropertiesJson
+	}
+	return nil
+}
+
+type ListResult struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Resources     []*ResourceStatusResult `protobuf:"bytes,1,rep,name=resources,proto3" json:"resources,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListResult) Reset() {
+	*x = ListResult{}
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListResult) ProtoMessage() {}
+
+func (x *ListResult) ProtoReflect() protoreflect.Message {
+	mi := &file_boxyagent_v1_agent_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListResult.ProtoReflect.Descriptor instead.
+func (*ListResult) Descriptor() ([]byte, []int) {
+	return file_boxyagent_v1_agent_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ListResult) GetResources() []*ResourceStatusResult {
+	if x != nil {
+		return x.Resources
 	}
 	return nil
 }
@@ -1216,7 +1331,7 @@ const file_boxyagent_v1_agent_proto_rawDesc = "" +
 	"\tHeartbeat\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x1b\n" +
 	"\tunix_time\x18\x02 \x01(\x03R\bunixTime\x12%\n" +
-	"\x0eprovider_types\x18\x03 \x03(\tR\rproviderTypes\"\x94\x03\n" +
+	"\x0eprovider_types\x18\x03 \x03(\tR\rproviderTypes\"\xc4\x03\n" +
 	"\rCommandResult\x12\x1d\n" +
 	"\n" +
 	"command_id\x18\x01 \x01(\tR\tcommandId\x12:\n" +
@@ -1225,7 +1340,8 @@ const file_boxyagent_v1_agent_proto_rawDesc = "" +
 	"\toperation\x18\x04 \x01(\v2\x1d.boxyagent.v1.OperationResultH\x00R\toperation\x122\n" +
 	"\adeleted\x18\x05 \x01(\v2\x16.google.protobuf.EmptyH\x00R\adeleted\x12:\n" +
 	"\ballocate\x18\x06 \x01(\v2\x1c.boxyagent.v1.AllocateResultH\x00R\ballocate\x120\n" +
-	"\x05error\x18\a \x01(\v2\x18.boxyagent.v1.AgentErrorH\x00R\x05errorB\t\n" +
+	"\x05error\x18\a \x01(\v2\x18.boxyagent.v1.AgentErrorH\x00R\x05error\x12.\n" +
+	"\x04list\x18\b \x01(\v2\x18.boxyagent.v1.ListResultH\x00R\x04listB\t\n" +
 	"\aoutcome\"&\n" +
 	"\n" +
 	"AgentError\x12\x18\n" +
@@ -1241,7 +1357,7 @@ const file_boxyagent_v1_agent_proto_rawDesc = "" +
 	"\x16client_certificate_pem\x18\x02 \x01(\fR\x14clientCertificatePem\x123\n" +
 	"\x16client_private_key_pem\x18\x05 \x01(\fR\x13clientPrivateKeyPem\x12,\n" +
 	"\x12ca_certificate_pem\x18\x03 \x01(\fR\x10caCertificatePem\x12<\n" +
-	"\x1aheartbeat_interval_seconds\x18\x04 \x01(\x05R\x18heartbeatIntervalSeconds\"\xe6\x02\n" +
+	"\x1aheartbeat_interval_seconds\x18\x04 \x01(\x05R\x18heartbeatIntervalSeconds\"\x97\x03\n" +
 	"\aCommand\x12\x1d\n" +
 	"\n" +
 	"command_id\x18\x01 \x01(\tR\tcommandId\x12#\n" +
@@ -1250,7 +1366,8 @@ const file_boxyagent_v1_agent_proto_rawDesc = "" +
 	"\x04read\x18\x04 \x01(\v2\x19.boxyagent.v1.ReadCommandH\x00R\x04read\x125\n" +
 	"\x06update\x18\x05 \x01(\v2\x1b.boxyagent.v1.UpdateCommandH\x00R\x06update\x125\n" +
 	"\x06delete\x18\x06 \x01(\v2\x1b.boxyagent.v1.DeleteCommandH\x00R\x06delete\x12;\n" +
-	"\ballocate\x18\a \x01(\v2\x1d.boxyagent.v1.AllocateCommandH\x00R\ballocateB\x04\n" +
+	"\ballocate\x18\a \x01(\v2\x1d.boxyagent.v1.AllocateCommandH\x00R\ballocate\x12/\n" +
+	"\x04list\x18\b \x01(\v2\x19.boxyagent.v1.ListCommandH\x00R\x04listB\x04\n" +
 	"\x02op\"0\n" +
 	"\rCreateCommand\x12\x1f\n" +
 	"\vconfig_json\x18\x01 \x01(\fR\n" +
@@ -1267,7 +1384,8 @@ const file_boxyagent_v1_agent_proto_rawDesc = "" +
 	"resourceId\"2\n" +
 	"\x0fAllocateCommand\x12\x1f\n" +
 	"\vresource_id\x18\x01 \x01(\tR\n" +
-	"resourceId\"\xc3\x02\n" +
+	"resourceId\"\r\n" +
+	"\vListCommand\"\xc3\x02\n" +
 	"\x0eResourceResult\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12Y\n" +
 	"\x0fconnection_info\x18\x02 \x03(\v20.boxyagent.v1.ResourceResult.ConnectionInfoEntryR\x0econnectionInfo\x12F\n" +
@@ -1287,7 +1405,10 @@ const file_boxyagent_v1_agent_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"9\n" +
 	"\x0eAllocateResult\x12'\n" +
-	"\x0fproperties_json\x18\x01 \x01(\fR\x0epropertiesJson2_\n" +
+	"\x0fproperties_json\x18\x01 \x01(\fR\x0epropertiesJson\"N\n" +
+	"\n" +
+	"ListResult\x12@\n" +
+	"\tresources\x18\x01 \x03(\v2\".boxyagent.v1.ResourceStatusResultR\tresources2_\n" +
 	"\x15AgentTransportService\x12F\n" +
 	"\aConnect\x12\x1a.boxyagent.v1.AgentMessage\x1a\x1b.boxyagent.v1.ServerMessage(\x010\x01B@Z>github.com/Geogboe/boxy/pkg/agentproto/boxyagentv1;boxyagentv1b\x06proto3"
 
@@ -1303,7 +1424,7 @@ func file_boxyagent_v1_agent_proto_rawDescGZIP() []byte {
 	return file_boxyagent_v1_agent_proto_rawDescData
 }
 
-var file_boxyagent_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_boxyagent_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_boxyagent_v1_agent_proto_goTypes = []any{
 	(*AgentMessage)(nil),         // 0: boxyagent.v1.AgentMessage
 	(*RegisterRequest)(nil),      // 1: boxyagent.v1.RegisterRequest
@@ -1318,42 +1439,47 @@ var file_boxyagent_v1_agent_proto_goTypes = []any{
 	(*UpdateCommand)(nil),        // 10: boxyagent.v1.UpdateCommand
 	(*DeleteCommand)(nil),        // 11: boxyagent.v1.DeleteCommand
 	(*AllocateCommand)(nil),      // 12: boxyagent.v1.AllocateCommand
-	(*ResourceResult)(nil),       // 13: boxyagent.v1.ResourceResult
-	(*ResourceStatusResult)(nil), // 14: boxyagent.v1.ResourceStatusResult
-	(*OperationResult)(nil),      // 15: boxyagent.v1.OperationResult
-	(*AllocateResult)(nil),       // 16: boxyagent.v1.AllocateResult
-	nil,                          // 17: boxyagent.v1.ResourceResult.ConnectionInfoEntry
-	nil,                          // 18: boxyagent.v1.ResourceResult.MetadataEntry
-	nil,                          // 19: boxyagent.v1.OperationResult.OutputsEntry
-	(*emptypb.Empty)(nil),        // 20: google.protobuf.Empty
+	(*ListCommand)(nil),          // 13: boxyagent.v1.ListCommand
+	(*ResourceResult)(nil),       // 14: boxyagent.v1.ResourceResult
+	(*ResourceStatusResult)(nil), // 15: boxyagent.v1.ResourceStatusResult
+	(*OperationResult)(nil),      // 16: boxyagent.v1.OperationResult
+	(*AllocateResult)(nil),       // 17: boxyagent.v1.AllocateResult
+	(*ListResult)(nil),           // 18: boxyagent.v1.ListResult
+	nil,                          // 19: boxyagent.v1.ResourceResult.ConnectionInfoEntry
+	nil,                          // 20: boxyagent.v1.ResourceResult.MetadataEntry
+	nil,                          // 21: boxyagent.v1.OperationResult.OutputsEntry
+	(*emptypb.Empty)(nil),        // 22: google.protobuf.Empty
 }
 var file_boxyagent_v1_agent_proto_depIdxs = []int32{
 	1,  // 0: boxyagent.v1.AgentMessage.register:type_name -> boxyagent.v1.RegisterRequest
 	2,  // 1: boxyagent.v1.AgentMessage.heartbeat:type_name -> boxyagent.v1.Heartbeat
 	3,  // 2: boxyagent.v1.AgentMessage.result:type_name -> boxyagent.v1.CommandResult
-	13, // 3: boxyagent.v1.CommandResult.resource:type_name -> boxyagent.v1.ResourceResult
-	14, // 4: boxyagent.v1.CommandResult.status:type_name -> boxyagent.v1.ResourceStatusResult
-	15, // 5: boxyagent.v1.CommandResult.operation:type_name -> boxyagent.v1.OperationResult
-	20, // 6: boxyagent.v1.CommandResult.deleted:type_name -> google.protobuf.Empty
-	16, // 7: boxyagent.v1.CommandResult.allocate:type_name -> boxyagent.v1.AllocateResult
+	14, // 3: boxyagent.v1.CommandResult.resource:type_name -> boxyagent.v1.ResourceResult
+	15, // 4: boxyagent.v1.CommandResult.status:type_name -> boxyagent.v1.ResourceStatusResult
+	16, // 5: boxyagent.v1.CommandResult.operation:type_name -> boxyagent.v1.OperationResult
+	22, // 6: boxyagent.v1.CommandResult.deleted:type_name -> google.protobuf.Empty
+	17, // 7: boxyagent.v1.CommandResult.allocate:type_name -> boxyagent.v1.AllocateResult
 	4,  // 8: boxyagent.v1.CommandResult.error:type_name -> boxyagent.v1.AgentError
-	6,  // 9: boxyagent.v1.ServerMessage.registered:type_name -> boxyagent.v1.RegisterResponse
-	7,  // 10: boxyagent.v1.ServerMessage.command:type_name -> boxyagent.v1.Command
-	8,  // 11: boxyagent.v1.Command.create:type_name -> boxyagent.v1.CreateCommand
-	9,  // 12: boxyagent.v1.Command.read:type_name -> boxyagent.v1.ReadCommand
-	10, // 13: boxyagent.v1.Command.update:type_name -> boxyagent.v1.UpdateCommand
-	11, // 14: boxyagent.v1.Command.delete:type_name -> boxyagent.v1.DeleteCommand
-	12, // 15: boxyagent.v1.Command.allocate:type_name -> boxyagent.v1.AllocateCommand
-	17, // 16: boxyagent.v1.ResourceResult.connection_info:type_name -> boxyagent.v1.ResourceResult.ConnectionInfoEntry
-	18, // 17: boxyagent.v1.ResourceResult.metadata:type_name -> boxyagent.v1.ResourceResult.MetadataEntry
-	19, // 18: boxyagent.v1.OperationResult.outputs:type_name -> boxyagent.v1.OperationResult.OutputsEntry
-	0,  // 19: boxyagent.v1.AgentTransportService.Connect:input_type -> boxyagent.v1.AgentMessage
-	5,  // 20: boxyagent.v1.AgentTransportService.Connect:output_type -> boxyagent.v1.ServerMessage
-	20, // [20:21] is the sub-list for method output_type
-	19, // [19:20] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	18, // 9: boxyagent.v1.CommandResult.list:type_name -> boxyagent.v1.ListResult
+	6,  // 10: boxyagent.v1.ServerMessage.registered:type_name -> boxyagent.v1.RegisterResponse
+	7,  // 11: boxyagent.v1.ServerMessage.command:type_name -> boxyagent.v1.Command
+	8,  // 12: boxyagent.v1.Command.create:type_name -> boxyagent.v1.CreateCommand
+	9,  // 13: boxyagent.v1.Command.read:type_name -> boxyagent.v1.ReadCommand
+	10, // 14: boxyagent.v1.Command.update:type_name -> boxyagent.v1.UpdateCommand
+	11, // 15: boxyagent.v1.Command.delete:type_name -> boxyagent.v1.DeleteCommand
+	12, // 16: boxyagent.v1.Command.allocate:type_name -> boxyagent.v1.AllocateCommand
+	13, // 17: boxyagent.v1.Command.list:type_name -> boxyagent.v1.ListCommand
+	19, // 18: boxyagent.v1.ResourceResult.connection_info:type_name -> boxyagent.v1.ResourceResult.ConnectionInfoEntry
+	20, // 19: boxyagent.v1.ResourceResult.metadata:type_name -> boxyagent.v1.ResourceResult.MetadataEntry
+	21, // 20: boxyagent.v1.OperationResult.outputs:type_name -> boxyagent.v1.OperationResult.OutputsEntry
+	15, // 21: boxyagent.v1.ListResult.resources:type_name -> boxyagent.v1.ResourceStatusResult
+	0,  // 22: boxyagent.v1.AgentTransportService.Connect:input_type -> boxyagent.v1.AgentMessage
+	5,  // 23: boxyagent.v1.AgentTransportService.Connect:output_type -> boxyagent.v1.ServerMessage
+	23, // [23:24] is the sub-list for method output_type
+	22, // [22:23] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_boxyagent_v1_agent_proto_init() }
@@ -1373,6 +1499,7 @@ func file_boxyagent_v1_agent_proto_init() {
 		(*CommandResult_Deleted)(nil),
 		(*CommandResult_Allocate)(nil),
 		(*CommandResult_Error)(nil),
+		(*CommandResult_List)(nil),
 	}
 	file_boxyagent_v1_agent_proto_msgTypes[5].OneofWrappers = []any{
 		(*ServerMessage_Registered)(nil),
@@ -1384,6 +1511,7 @@ func file_boxyagent_v1_agent_proto_init() {
 		(*Command_Update)(nil),
 		(*Command_Delete)(nil),
 		(*Command_Allocate)(nil),
+		(*Command_List)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1391,7 +1519,7 @@ func file_boxyagent_v1_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_boxyagent_v1_agent_proto_rawDesc), len(file_boxyagent_v1_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/agentsdk/agent.go
+++ b/pkg/agentsdk/agent.go
@@ -51,6 +51,14 @@ type GuestPersonalizingAgent interface {
 	PersonalizeGuest(ctx context.Context, provider providersdk.Type, id string) (*providersdk.GuestPersonalizationResult, error)
 }
 
+// ResourceListingAgent is an optional agent capability for providers whose
+// underlying driver implements providersdk.ResourceLister. Not every driver
+// supports enumeration, so callers must type-assert for this rather than
+// relying on it being part of Agent.
+type ResourceListingAgent interface {
+	List(ctx context.Context, provider providersdk.Type) ([]providersdk.ResourceStatus, error)
+}
+
 // AgentInfo describes an agent and the providers it hosts.
 type AgentInfo struct {
 	// ID is a unique identifier for this agent instance.

--- a/pkg/agentsdk/embedded.go
+++ b/pkg/agentsdk/embedded.go
@@ -83,6 +83,23 @@ func (a *EmbeddedAgent) Allocate(ctx context.Context, provider providersdk.Type,
 	return d.Allocate(ctx, id)
 }
 
+// List satisfies ResourceListingAgent for drivers that implement
+// providersdk.ResourceLister. Returns an error for drivers that don't —
+// callers must treat "list not supported" and "list failed" the same way
+// (see docs/adr/0005-remote-agent-transport-and-registration.md's
+// discussion of #133).
+func (a *EmbeddedAgent) List(ctx context.Context, provider providersdk.Type) ([]providersdk.ResourceStatus, error) {
+	d, err := a.driver(provider)
+	if err != nil {
+		return nil, err
+	}
+	lister, ok := d.(providersdk.ResourceLister)
+	if !ok {
+		return nil, fmt.Errorf("agent %q: provider %q does not support listing", a.info.ID, provider)
+	}
+	return lister.List(ctx)
+}
+
 func (a *EmbeddedAgent) PersonalizeGuest(ctx context.Context, provider providersdk.Type, id string) (*providersdk.GuestPersonalizationResult, error) {
 	d, err := a.driver(provider)
 	if err != nil {

--- a/pkg/agentsdk/embedded_test.go
+++ b/pkg/agentsdk/embedded_test.go
@@ -110,6 +110,23 @@ func TestEmbeddedAgent_UnknownProviderForEveryLifecycleMethod(t *testing.T) {
 	if result, err := agent.PersonalizeGuest(ctx, missing, "res-1"); err == nil || result != nil {
 		t.Fatalf("PersonalizeGuest unknown provider result=%v err=%v, want error", result, err)
 	}
+	if _, err := agent.List(ctx, missing); err == nil {
+		t.Fatal("List unknown provider error = nil")
+	}
+}
+
+// TestEmbeddedAgent_ListReturnsErrorForDriverWithoutCapability verifies that
+// an unsupported List returns an error rather than an empty slice — an empty
+// slice would be indistinguishable from "confirmed nothing exists," which
+// the #133 reconciliation sweep must never assume for a driver that simply
+// can't enumerate.
+func TestEmbeddedAgent_ListReturnsErrorForDriverWithoutCapability(t *testing.T) {
+	agent := newTestAgent(t)
+
+	statuses, err := agent.List(context.Background(), devfactory.ProviderType)
+	if err == nil {
+		t.Fatalf("List result = %+v, err = nil; want error for driver without ResourceLister", statuses)
+	}
 }
 
 func TestEmbeddedAgent_PersonalizeGuestReturnsNilForDriverWithoutCapability(t *testing.T) {

--- a/pkg/agentsdk/remote.go
+++ b/pkg/agentsdk/remote.go
@@ -243,6 +243,34 @@ func (a *RemoteAgent) Delete(ctx context.Context, provider providersdk.Type, id 
 	return nil
 }
 
+// List satisfies ResourceListingAgent by sending a ListCommand. The remote
+// agent's executeCommand returns an AgentError if its driver doesn't
+// implement providersdk.ResourceLister — same error path as any other
+// command failure, deliberately not distinguished from a transient failure
+// (see docs/adr/0005-remote-agent-transport-and-registration.md's
+// discussion of #133).
+func (a *RemoteAgent) List(ctx context.Context, provider providersdk.Type) ([]providersdk.ResourceStatus, error) {
+	res, err := a.call(ctx, &boxyagentv1.Command{
+		ProviderType: string(provider),
+		Op:           &boxyagentv1.Command_List{List: &boxyagentv1.ListCommand{}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if agentErr := res.GetError(); agentErr != nil {
+		return nil, fmt.Errorf("agent %q: %s", a.info.ID, agentErr.GetMessage())
+	}
+	lr := res.GetList()
+	if lr == nil {
+		return nil, fmt.Errorf("agent %q: unexpected result for list", a.info.ID)
+	}
+	statuses := make([]providersdk.ResourceStatus, 0, len(lr.GetResources()))
+	for _, r := range lr.GetResources() {
+		statuses = append(statuses, providersdk.ResourceStatus{ID: r.GetId(), State: r.GetState()})
+	}
+	return statuses, nil
+}
+
 // Allocate does not implement GuestPersonalizingAgent: the transport's
 // AllocateCommand/AllocateResult only carries generic JSON properties, not
 // providersdk.GuestAccessDetails' richer typed shape. A remote driver that

--- a/pkg/agentsdk/remote_test.go
+++ b/pkg/agentsdk/remote_test.go
@@ -128,6 +128,82 @@ func TestRemoteAgent_CreateRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRemoteAgent_ListRoundTrip(t *testing.T) {
+	stream := newFakeServerStream()
+	a := NewRemoteAgent(AgentInfo{ID: "agent-1"}, stream)
+	go func() { _ = a.Serve() }()
+
+	type result struct {
+		statuses []providersdk.ResourceStatus
+		err      error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		statuses, err := a.List(context.Background(), "docker")
+		resultCh <- result{statuses, err}
+	}()
+
+	cmd := recvCommand(t, stream.sentCh)
+	if cmd.GetList() == nil {
+		t.Fatalf("expected a ListCommand, got %#v", cmd)
+	}
+
+	stream.feedResult(&boxyagentv1.CommandResult{
+		CommandId: cmd.GetCommandId(),
+		Outcome: &boxyagentv1.CommandResult_List{List: &boxyagentv1.ListResult{
+			Resources: []*boxyagentv1.ResourceStatusResult{
+				{Id: "container-1", State: "running"},
+				{Id: "container-2", State: "exited"},
+			},
+		}},
+	})
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			t.Fatalf("List returned error: %v", r.err)
+		}
+		if len(r.statuses) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(r.statuses))
+		}
+		if r.statuses[0].ID != "container-1" || r.statuses[0].State != "running" {
+			t.Fatalf("unexpected first status: %+v", r.statuses[0])
+		}
+		if r.statuses[1].ID != "container-2" || r.statuses[1].State != "exited" {
+			t.Fatalf("unexpected second status: %+v", r.statuses[1])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for List to return")
+	}
+}
+
+func TestRemoteAgent_ListErrorPropagates(t *testing.T) {
+	stream := newFakeServerStream()
+	a := NewRemoteAgent(AgentInfo{ID: "agent-1"}, stream)
+	go func() { _ = a.Serve() }()
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := a.List(context.Background(), "hyperv")
+		resultCh <- err
+	}()
+
+	cmd := recvCommand(t, stream.sentCh)
+	stream.feedResult(&boxyagentv1.CommandResult{
+		CommandId: cmd.GetCommandId(),
+		Outcome:   &boxyagentv1.CommandResult_Error{Error: &boxyagentv1.AgentError{Message: "list not supported by driver \"hyperv\""}},
+	})
+
+	select {
+	case err := <-resultCh:
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for List to return")
+	}
+}
+
 func TestRemoteAgent_ConcurrentCallsResolveDistinctWaiters(t *testing.T) {
 	stream := newFakeServerStream()
 	a := NewRemoteAgent(AgentInfo{ID: "agent-1"}, stream)

--- a/pkg/agentsdk/remoteclient.go
+++ b/pkg/agentsdk/remoteclient.go
@@ -285,6 +285,24 @@ func executeCommand(ctx context.Context, drivers DriverSet, cmd *boxyagentv1.Com
 			Outcome:   &boxyagentv1.CommandResult_Deleted{Deleted: &emptypb.Empty{}},
 		}
 
+	case *boxyagentv1.Command_List:
+		lister, ok := d.(providersdk.ResourceLister)
+		if !ok {
+			return errorResult(cmd.GetCommandId(), fmt.Sprintf("list not supported by driver %q", cmd.GetProviderType()))
+		}
+		statuses, err := lister.List(ctx)
+		if err != nil {
+			return errorResult(cmd.GetCommandId(), err.Error())
+		}
+		resources := make([]*boxyagentv1.ResourceStatusResult, 0, len(statuses))
+		for _, st := range statuses {
+			resources = append(resources, &boxyagentv1.ResourceStatusResult{Id: st.ID, State: st.State})
+		}
+		return &boxyagentv1.CommandResult{
+			CommandId: cmd.GetCommandId(),
+			Outcome:   &boxyagentv1.CommandResult_List{List: &boxyagentv1.ListResult{Resources: resources}},
+		}
+
 	case *boxyagentv1.Command_Allocate:
 		props, err := d.Allocate(ctx, op.Allocate.GetResourceId())
 		if err != nil {

--- a/pkg/agentsdk/remoteclient_test.go
+++ b/pkg/agentsdk/remoteclient_test.go
@@ -54,6 +54,20 @@ func (d *fakeDriver) Allocate(ctx context.Context, id string) (map[string]any, e
 	return d.allocateRes, d.allocateErr
 }
 
+// fakeListingDriver adds providersdk.ResourceLister on top of fakeDriver, so
+// tests can exercise both the "driver supports List" and "driver doesn't"
+// paths through executeCommand — the latter using plain *fakeDriver, which
+// deliberately has no List method.
+type fakeListingDriver struct {
+	*fakeDriver
+	listErr error
+	listRes []providersdk.ResourceStatus
+}
+
+func (d *fakeListingDriver) List(ctx context.Context) ([]providersdk.ResourceStatus, error) {
+	return d.listRes, d.listErr
+}
+
 func TestExecuteCommand(t *testing.T) {
 	drivers := DriverSet{
 		"docker": &fakeDriver{
@@ -134,6 +148,41 @@ func TestExecuteCommand(t *testing.T) {
 		}
 		if props["port"] != float64(2222) {
 			t.Fatalf("expected numeric property to round-trip, got %#v", props["port"])
+		}
+	})
+
+	t.Run("list success", func(t *testing.T) {
+		drivers := DriverSet{"docker": &fakeListingDriver{
+			fakeDriver: &fakeDriver{providerType: "docker"},
+			listRes: []providersdk.ResourceStatus{
+				{ID: "c1", State: "running"},
+				{ID: "c2", State: "exited"},
+			},
+		}}
+		cmd := &boxyagentv1.Command{
+			CommandId:    "cmd-8",
+			ProviderType: "docker",
+			Op:           &boxyagentv1.Command_List{List: &boxyagentv1.ListCommand{}},
+		}
+		res := executeCommand(context.Background(), drivers, cmd)
+		if res.GetError() != nil {
+			t.Fatalf("unexpected error: %s", res.GetError().GetMessage())
+		}
+		got := res.GetList().GetResources()
+		if len(got) != 2 || got[0].GetId() != "c1" || got[1].GetId() != "c2" {
+			t.Fatalf("unexpected list result: %#v", got)
+		}
+	})
+
+	t.Run("list unsupported by driver errors", func(t *testing.T) {
+		cmd := &boxyagentv1.Command{
+			CommandId:    "cmd-9",
+			ProviderType: "docker",
+			Op:           &boxyagentv1.Command_List{List: &boxyagentv1.ListCommand{}},
+		}
+		res := executeCommand(context.Background(), drivers, cmd)
+		if res.GetError() == nil {
+			t.Fatal("expected an error result for a driver without ResourceLister")
 		}
 	})
 

--- a/pkg/providersdk/driver.go
+++ b/pkg/providersdk/driver.go
@@ -79,3 +79,12 @@ type Result struct {
 	// (e.g. generated credentials, captured stdout).
 	Outputs map[string]string
 }
+
+// ResourceLister is an optional provider capability for enumerating every
+// resource the driver currently manages, independent of any single resource
+// ID. Not every driver can support this (see docker's implementation for the
+// managed-resource tagging convention this depends on) — callers must type-
+// assert for it rather than relying on it being part of Driver.
+type ResourceLister interface {
+	List(ctx context.Context) ([]ResourceStatus, error)
+}

--- a/pkg/providersdk/providers/docker/driver.go
+++ b/pkg/providersdk/providers/docker/driver.go
@@ -16,6 +16,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
@@ -27,6 +28,15 @@ import (
 	"github.com/Geogboe/boxy/pkg/providersdk"
 )
 
+// managedLabel/managedLabelValue tag every container this driver creates so
+// List can distinguish boxy-managed containers from unrelated ones on the
+// same docker host. Stamped unconditionally at Create time — not
+// user-overridable via config.Labels.
+const (
+	managedLabel      = "boxy.managed"
+	managedLabelValue = "true"
+)
+
 // dockerClient is the minimal Docker API surface used by this driver.
 // *client.Client satisfies this interface; tests inject a mock.
 type dockerClient interface {
@@ -35,6 +45,7 @@ type dockerClient interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
+	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	ContainerLogs(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
 	ContainerExecCreate(ctx context.Context, containerID string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
@@ -114,11 +125,17 @@ func (d *Driver) Create(ctx context.Context, cfg any) (*providersdk.Resource, er
 		}
 	}
 
+	labels := make(map[string]string, len(cc.Labels)+1)
+	for k, v := range cc.Labels {
+		labels[k] = v
+	}
+	labels[managedLabel] = managedLabelValue
+
 	containerCfg := &container.Config{
 		Image:        cc.Image,
 		Cmd:          command,
 		Env:          envList,
-		Labels:       cc.Labels,
+		Labels:       labels,
 		ExposedPorts: exposedPorts,
 		AttachStdin:  needsInteractive,
 		OpenStdin:    needsInteractive,
@@ -196,6 +213,23 @@ func (d *Driver) Read(ctx context.Context, id string) (*providersdk.ResourceStat
 		ID:    id,
 		State: info.State.Status,
 	}, nil
+}
+
+// List returns every container this driver created, identified by
+// managedLabel. It satisfies providersdk.ResourceLister.
+func (d *Driver) List(ctx context.Context) ([]providersdk.ResourceStatus, error) {
+	summaries, err := d.cli.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("label", managedLabel+"="+managedLabelValue)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("docker ContainerList: %w", err)
+	}
+	statuses := make([]providersdk.ResourceStatus, 0, len(summaries))
+	for _, c := range summaries {
+		statuses = append(statuses, providersdk.ResourceStatus{ID: c.ID, State: c.State})
+	}
+	return statuses, nil
 }
 
 func (d *Driver) Update(ctx context.Context, id string, op providersdk.Operation) (*providersdk.Result, error) {

--- a/pkg/providersdk/providers/docker/driver_test.go
+++ b/pkg/providersdk/providers/docker/driver_test.go
@@ -28,6 +28,7 @@ type mockDockerClient struct {
 	containerCreate      func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	containerStart       func(ctx context.Context, containerID string, options container.StartOptions) error
 	containerInspect     func(ctx context.Context, containerID string) (container.InspectResponse, error)
+	containerList        func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	containerLogs        func(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
 	containerExecCreate  func(ctx context.Context, containerID string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	containerExecAttach  func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
@@ -55,6 +56,12 @@ func (m *mockDockerClient) ContainerStart(ctx context.Context, id string, opts c
 }
 func (m *mockDockerClient) ContainerInspect(ctx context.Context, id string) (container.InspectResponse, error) {
 	return m.containerInspect(ctx, id)
+}
+func (m *mockDockerClient) ContainerList(ctx context.Context, opts container.ListOptions) ([]container.Summary, error) {
+	if m.containerList != nil {
+		return m.containerList(ctx, opts)
+	}
+	return nil, nil
 }
 func (m *mockDockerClient) ContainerLogs(ctx context.Context, id string, opts container.LogsOptions) (io.ReadCloser, error) {
 	if m.containerLogs != nil {
@@ -353,6 +360,71 @@ func TestDriver_Read_Error(t *testing.T) {
 	}
 	d := &Driver{cli: mock}
 	_, err := d.Read(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- List ---
+
+func TestDriver_List_FiltersByManagedLabel(t *testing.T) {
+	mock := &mockDockerClient{
+		containerList: func(_ context.Context, opts container.ListOptions) ([]container.Summary, error) {
+			if !opts.All {
+				t.Errorf("expected All=true so stopped containers are included")
+			}
+			if opts.Filters.Len() != 1 {
+				t.Fatalf("expected exactly one filter, got %d", opts.Filters.Len())
+			}
+			if !opts.Filters.ExactMatch("label", managedLabel+"="+managedLabelValue) {
+				t.Errorf("expected label filter %s=%s", managedLabel, managedLabelValue)
+			}
+			return []container.Summary{
+				{ID: "abc", State: "running"},
+				{ID: "def", State: "exited"},
+			}, nil
+		},
+	}
+	d := &Driver{cli: mock}
+	statuses, err := d.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("got %d statuses, want 2", len(statuses))
+	}
+	if statuses[0].ID != "abc" || statuses[0].State != "running" {
+		t.Errorf("unexpected first status: %+v", statuses[0])
+	}
+	if statuses[1].ID != "def" || statuses[1].State != "exited" {
+		t.Errorf("unexpected second status: %+v", statuses[1])
+	}
+}
+
+func TestDriver_List_Empty(t *testing.T) {
+	mock := &mockDockerClient{
+		containerList: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			return nil, nil
+		},
+	}
+	d := &Driver{cli: mock}
+	statuses, err := d.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(statuses) != 0 {
+		t.Errorf("got %d statuses, want 0", len(statuses))
+	}
+}
+
+func TestDriver_List_Error(t *testing.T) {
+	mock := &mockDockerClient{
+		containerList: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			return nil, fmt.Errorf("docker daemon unreachable")
+		},
+	}
+	d := &Driver{cli: mock}
+	_, err := d.List(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/proto/boxyagent/v1/agent.proto
+++ b/proto/boxyagent/v1/agent.proto
@@ -50,6 +50,7 @@ message CommandResult {
     google.protobuf.Empty deleted = 5;
     AllocateResult allocate = 6;
     AgentError error = 7;
+    ListResult list = 8;
   }
 }
 
@@ -88,6 +89,7 @@ message Command {
     UpdateCommand update = 5;
     DeleteCommand delete = 6;
     AllocateCommand allocate = 7;
+    ListCommand list = 8;
   }
 }
 
@@ -117,6 +119,11 @@ message AllocateCommand {
   string resource_id = 1;
 }
 
+// ListCommand requests every resource the driver currently manages for
+// provider_type. It carries no fields of its own — enumeration is
+// unconditional, unlike the other commands which target one resource_id.
+message ListCommand {}
+
 message ResourceResult {
   string id = 1;
   map<string, string> connection_info = 2;
@@ -140,4 +147,8 @@ message OperationResult {
 // any JSON-representable value).
 message AllocateResult {
   bytes properties_json = 1;
+}
+
+message ListResult {
+  repeated ResourceStatusResult resources = 1;
 }


### PR DESCRIPTION
## Summary
First of two PRs for #133 (post-reconnect reconciliation sweep, follow-up from ADR-0005). This PR adds the enumeration capability the sweep needs; the sweep itself (using `pkg/policycontroller`) lands in a follow-up PR.

- Proto: `ListCommand`/`ListResult` added to the agent transport (`Command`/`CommandResult` oneofs).
- `providersdk.ResourceLister`: optional driver capability (mirrors `GuestPersonalizer`) for enumerating everything a driver manages.
- Docker driver implements `List`: containers are now stamped with a `boxy.managed` label at `Create` time (not user-overridable), and `List` filters `ContainerList` by that label.
- `agentsdk.ResourceListingAgent`: optional agent capability (mirrors `GuestPersonalizingAgent`). `EmbeddedAgent.List` type-asserts the driver; `RemoteAgent.List` sends a `ListCommand` over the transport; `remoteclient.go`'s dispatcher executes it against the local driver set.

**Scope decision**: docker-only this cycle. hyperv/devfactory have no existing managed-resource tagging convention, and inventing one for each under this issue would be a bigger lift than the reconciliation sweep itself — tracked as a follow-up rather than rushed here. Agents whose driver doesn't support `List` return a plain error, which the reconciliation sweep (next PR) treats the same as any other failure: skip auditing that agent this pass, don't assume "confirmed empty."

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues (3 known gofmt CRLF false positives on unrelated files, pre-existing on Windows)
- [x] New unit tests: docker driver `List` (label filtering, empty, error), `EmbeddedAgent.List` (unsupported driver → error, not empty), `RemoteAgent.List` round-trip + error propagation, `executeCommand` List success/unsupported cases