### PR TITLE
feat(#133): post-reconnect reconciliation sweep

### DIFF
--- a/internal/agentserver/server.go
+++ b/internal/agentserver/server.go
@@ -33,6 +33,11 @@ import (
 // intervals mark an agent unavailable for new provisioning.
 const DefaultMissedHeartbeatLimit = 3
 
+// reconciliationTimeout bounds the #133 post-registration reconciliation
+// sweep so a slow or hung List call can't hold resources indefinitely; the
+// sweep is best-effort and logs rather than fails the connection either way.
+const reconciliationTimeout = 30 * time.Second
+
 // Server implements the generated AgentTransportServiceServer.
 type Server struct {
 	boxyagentv1.UnimplementedAgentTransportServiceServer
@@ -184,6 +189,20 @@ func (s *Server) Connect(stream boxyagentv1.AgentTransportService_ConnectServer)
 	// too (its own Close() is idempotent, guarded by sync.Once).
 	serveDone := make(chan error, 1)
 	go func() { serveDone <- remote.Serve() }()
+
+	// The #133 reconciliation sweep needs Serve() already pumping the
+	// stream (List is itself a command sent down it), so it can only start
+	// here, not before. Runs on every successful registration, not just
+	// reconnects — see pool.ReconcileAgent's doc comment. Bounded and
+	// logged-only: reconciliation trouble must never take down agent
+	// connectivity.
+	go func() {
+		rctx, cancel := context.WithTimeout(ctx, reconciliationTimeout)
+		defer cancel()
+		if err := pool.ReconcileAgent(rctx, s.store, s.registry, agentID, s.log()); err != nil {
+			s.log().Warn("post-registration reconciliation failed", "agent_id", agentID, "error", err)
+		}
+	}()
 
 	select {
 	case err := <-serveDone:

--- a/internal/agentserver/server_test.go
+++ b/internal/agentserver/server_test.go
@@ -123,6 +123,83 @@ func TestConnect_TokenRegistrationHappyPath(t *testing.T) {
 	}
 }
 
+// TestConnect_TriggersReconciliationSweep verifies the #133 wiring end to
+// end: a successful registration must cause the server to send a
+// ListCommand down the stream (pool.ReconcileAgent auditing this agent),
+// and a resource the agent reports that the store never tracked must be
+// adopted.
+func TestConnect_TriggersReconciliationSweep(t *testing.T) {
+	_, st, client, cleanup := newTestServer(t)
+	defer cleanup()
+	mintToken(t, st, "tok-good", time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := client.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if err := stream.Send(&boxyagentv1.AgentMessage{
+		Payload: &boxyagentv1.AgentMessage_Register{Register: &boxyagentv1.RegisterRequest{
+			RegistrationToken: "tok-good",
+			AgentName:         "test-agent",
+			ProviderTypes:     []string{"docker"},
+		}},
+	}); err != nil {
+		t.Fatalf("send register request: %v", err)
+	}
+
+	msg, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv register response: %v", err)
+	}
+	agentID := msg.GetRegistered().GetAgentId()
+	if agentID == "" {
+		t.Fatal("expected a non-empty agent id")
+	}
+
+	// The reconciliation sweep starts once Serve() is pumping the stream
+	// (see server.go's Connect), so the next frame in is the ListCommand
+	// it issues, not anything test-driven.
+	cmdMsg, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv reconciliation command: %v", err)
+	}
+	cmd := cmdMsg.GetCommand()
+	if cmd == nil || cmd.GetList() == nil {
+		t.Fatalf("expected the server to issue a ListCommand for reconciliation, got %#v", cmdMsg)
+	}
+
+	if err := stream.Send(&boxyagentv1.AgentMessage{
+		Payload: &boxyagentv1.AgentMessage_Result{Result: &boxyagentv1.CommandResult{
+			CommandId: cmd.GetCommandId(),
+			Outcome: &boxyagentv1.CommandResult_List{List: &boxyagentv1.ListResult{
+				Resources: []*boxyagentv1.ResourceStatusResult{
+					{Id: "orphan-container", State: "running"},
+				},
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("send list result: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		res, err := st.GetResource(context.Background(), "orphan-container")
+		if err == nil {
+			if res.Provider.AgentID != agentID {
+				t.Fatalf("adopted resource has AgentID %q, want %q", res.Provider.AgentID, agentID)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("orphan-container was never adopted into the store: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestConnect_UnknownTokenRejected(t *testing.T) {
 	_, _, client, cleanup := newTestServer(t)
 	defer cleanup()

--- a/internal/pool/reconcile.go
+++ b/internal/pool/reconcile.go
@@ -1,0 +1,212 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Geogboe/boxy/pkg/agentsdk"
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/policycontroller"
+	"github.com/Geogboe/boxy/pkg/providersdk"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+// ReconcileAgent audits one agent's actual resources against the store's
+// belief, closing the leak window described in #133: a dropped Create whose
+// remote side actually succeeded leaves a resource the store never learns
+// about. It uses pkg/policycontroller.Controller, the same Observe->Decide->
+// Act shape internal/pool/manager.go already uses for pool inventory
+// reconciliation — a second consumer of that package rather than a new
+// abstraction.
+//
+// Deliberately scoped to two outcomes, not three: this cycle only implements
+// providersdk.ResourceLister for the docker driver (see #133's PR
+// description), and there is no existing convention anywhere in this
+// codebase for mapping a driver-native ResourceStatus.State string (e.g.
+// docker's "running"/"exited") onto model.ResourceState — inventing one here
+// would be unscoped guesswork. So this only adopts orphans and reaps
+// confirmed-gone resources; syncing state on resources both sides already
+// agree exist is left alone.
+//
+// Runs on every successful registration, not just reconnects — even a
+// brand-new agent identity can have pre-existing boxy-tagged resources from
+// a prior life (e.g. process restarted with a fresh cert).
+func ReconcileAgent(ctx context.Context, st store.Store, registry *AgentRegistry, agentID string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	ctrl := policycontroller.Controller[reconcileObserved, reconcilePlan]{
+		Observer:  reconcileObserver(st, registry, agentID, logger),
+		Evaluator: reconcileEvaluator(),
+		Actuator:  reconcileActuator(st, logger),
+		Logger:    logger,
+	}
+	_, err := ctrl.Reconcile(ctx)
+	return err
+}
+
+// remoteEntry pairs a driver-reported resource with the provider type it
+// came from, since providersdk.ResourceStatus itself carries no provider
+// identity.
+type remoteEntry struct {
+	provider providersdk.Type
+	status   providersdk.ResourceStatus
+}
+
+type reconcileObserved struct {
+	agentID string
+	tracked []model.Resource
+	remote  map[model.ResourceID]remoteEntry
+	// listedProviders holds, for every provider type successfully
+	// enumerated this pass, how many remote entries came back. A provider
+	// type absent from this map means List failed or is unsupported for it
+	// this pass — never trust an absence of remote data as "confirmed
+	// gone" for that provider type.
+	listedProviders map[providersdk.Type]int
+	now             time.Time
+}
+
+type reconcilePlan struct {
+	adopt  []model.Resource
+	reap   []model.ResourceID
+	reason string
+}
+
+func reconcileObserver(st store.Store, registry *AgentRegistry, agentID string, logger *slog.Logger) policycontroller.ObserverFunc[reconcileObserved] {
+	return func(ctx context.Context) (reconcileObserved, error) {
+		agent, ok := registry.Get(agentID)
+		if !ok {
+			return reconcileObserved{}, fmt.Errorf("reconcile agent %q: not registered", agentID)
+		}
+
+		remote := make(map[model.ResourceID]remoteEntry)
+		listed := make(map[providersdk.Type]int)
+
+		lister, ok := agent.(agentsdk.ResourceListingAgent)
+		if !ok {
+			logger.Warn("reconciliation: agent does not support listing, skipping audit", "agent_id", agentID)
+		} else {
+			for _, provider := range agent.Info().Providers {
+				statuses, err := lister.List(ctx, provider)
+				if err != nil {
+					// Unsupported driver and a transient failure both land
+					// here, deliberately indistinguishable (see
+					// pkg/agentsdk.RemoteAgent.List) — either way this
+					// pass can't trust data for this provider type.
+					logger.Warn("reconciliation: list failed, skipping audit for this provider type",
+						"agent_id", agentID, "provider", provider, "error", err)
+					continue
+				}
+				listed[provider] = len(statuses)
+				for _, s := range statuses {
+					remote[model.ResourceID(s.ID)] = remoteEntry{provider: provider, status: s}
+				}
+			}
+		}
+
+		all, err := st.ListResources(ctx)
+		if err != nil {
+			return reconcileObserved{}, fmt.Errorf("reconcile agent %q: list resources: %w", agentID, err)
+		}
+		tracked := make([]model.Resource, 0, len(all))
+		for _, res := range all {
+			if res.Provider.AgentID == agentID {
+				tracked = append(tracked, res)
+			}
+		}
+
+		return reconcileObserved{
+			agentID:         agentID,
+			tracked:         tracked,
+			remote:          remote,
+			listedProviders: listed,
+			now:             time.Now().UTC(),
+		}, nil
+	}
+}
+
+func reconcileEvaluator() policycontroller.EvaluatorFunc[reconcileObserved, reconcilePlan] {
+	return func(_ context.Context, obs reconcileObserved) (policycontroller.Decision[reconcilePlan], error) {
+		trackedIDs := make(map[model.ResourceID]struct{}, len(obs.tracked))
+		trackedCountByProvider := make(map[providersdk.Type]int)
+		for _, res := range obs.tracked {
+			trackedIDs[res.ID] = struct{}{}
+			trackedCountByProvider[providersdk.Type(res.Provider.Name)]++
+		}
+
+		var reap []model.ResourceID
+		for _, res := range obs.tracked {
+			provider := providersdk.Type(res.Provider.Name)
+			remoteCount, listedThisPass := obs.listedProviders[provider]
+			if !listedThisPass {
+				continue
+			}
+			// Safety valve: a provider type that came back completely
+			// empty while the store tracks resources under it is
+			// suspicious enough to not trust for reaping this pass, even
+			// though List returned no error. Defense in depth against a
+			// future driver bug that returns an empty result instead of
+			// an error on partial failure.
+			if remoteCount == 0 && trackedCountByProvider[provider] > 0 {
+				continue
+			}
+			if _, stillThere := obs.remote[res.ID]; !stillThere {
+				reap = append(reap, res.ID)
+			}
+		}
+
+		var adopt []model.Resource
+		for id, entry := range obs.remote {
+			if _, known := trackedIDs[id]; known {
+				continue
+			}
+			adopt = append(adopt, model.Resource{
+				ID:       id,
+				Type:     model.ResourceTypeUnknown,
+				Provider: model.ProviderRef{Name: string(entry.provider), AgentID: obs.agentID},
+				State:    model.ResourceStateUnknown,
+				Properties: map[string]any{
+					"reconciled_driver_state": entry.status.State,
+				},
+				CreatedAt: obs.now,
+				UpdatedAt: obs.now,
+			})
+		}
+
+		reason := fmt.Sprintf("agent=%s adopt=%d reap=%d", obs.agentID, len(adopt), len(reap))
+		return policycontroller.Decision[reconcilePlan]{
+			ShouldAct: len(adopt) > 0 || len(reap) > 0,
+			Plan:      reconcilePlan{adopt: adopt, reap: reap, reason: reason},
+			Reason:    reason,
+		}, nil
+	}
+}
+
+func reconcileActuator(st store.Store, logger *slog.Logger) policycontroller.ActuatorFunc[reconcilePlan] {
+	return func(ctx context.Context, plan reconcilePlan) error {
+		for _, res := range plan.adopt {
+			logger.Warn("reconciliation: adopting orphaned resource",
+				"agent_id", res.Provider.AgentID, "resource_id", res.ID, "provider", res.Provider.Name)
+			if err := st.PutResource(ctx, res); err != nil {
+				return fmt.Errorf("adopt resource %q: %w", res.ID, err)
+			}
+		}
+		for _, id := range plan.reap {
+			res, err := st.GetResource(ctx, id)
+			if err != nil {
+				return fmt.Errorf("reap resource %q: get: %w", id, err)
+			}
+			res.State = model.ResourceStateDestroyed
+			res.UpdatedAt = time.Now().UTC()
+			logger.Warn("reconciliation: marking resource destroyed, agent no longer reports it",
+				"agent_id", res.Provider.AgentID, "resource_id", id)
+			if err := st.PutResource(ctx, res); err != nil {
+				return fmt.Errorf("reap resource %q: put: %w", id, err)
+			}
+		}
+		return nil
+	}
+}

--- a/internal/pool/reconcile_test.go
+++ b/internal/pool/reconcile_test.go
@@ -1,0 +1,315 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/Geogboe/boxy/pkg/agentsdk"
+	"github.com/Geogboe/boxy/pkg/model"
+	"github.com/Geogboe/boxy/pkg/providersdk"
+	"github.com/Geogboe/boxy/pkg/store"
+)
+
+// --- reconcileEvaluator: diff logic, in isolation ---
+
+func TestReconcileEvaluator(t *testing.T) {
+	eval := reconcileEvaluator()
+
+	t.Run("adopts a remote resource the store never tracked", func(t *testing.T) {
+		obs := reconcileObserved{
+			agentID: "agent-1",
+			tracked: nil,
+			remote: map[model.ResourceID]remoteEntry{
+				"orphan-1": {provider: "docker", status: providersdk.ResourceStatus{ID: "orphan-1", State: "running"}},
+			},
+			listedProviders: map[providersdk.Type]int{"docker": 1},
+		}
+		decision, err := eval.Evaluate(context.Background(), obs)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if !decision.ShouldAct {
+			t.Fatal("expected ShouldAct=true")
+		}
+		if len(decision.Plan.adopt) != 1 || decision.Plan.adopt[0].ID != "orphan-1" {
+			t.Fatalf("unexpected adopt plan: %+v", decision.Plan.adopt)
+		}
+		if len(decision.Plan.reap) != 0 {
+			t.Fatalf("expected no reaps, got %+v", decision.Plan.reap)
+		}
+	})
+
+	t.Run("reaps a tracked resource the agent no longer reports", func(t *testing.T) {
+		obs := reconcileObserved{
+			agentID: "agent-1",
+			tracked: []model.Resource{
+				{ID: "gone-1", Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"}},
+				{ID: "still-here", Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"}},
+			},
+			remote: map[model.ResourceID]remoteEntry{
+				"still-here": {provider: "docker", status: providersdk.ResourceStatus{ID: "still-here", State: "running"}},
+			},
+			listedProviders: map[providersdk.Type]int{"docker": 1},
+		}
+		decision, err := eval.Evaluate(context.Background(), obs)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if len(decision.Plan.reap) != 1 || decision.Plan.reap[0] != "gone-1" {
+			t.Fatalf("unexpected reap plan: %+v", decision.Plan.reap)
+		}
+		if len(decision.Plan.adopt) != 0 {
+			t.Fatalf("expected no adopts, got %+v", decision.Plan.adopt)
+		}
+	})
+
+	t.Run("never reaps a provider type that failed to list this pass", func(t *testing.T) {
+		obs := reconcileObserved{
+			agentID: "agent-1",
+			tracked: []model.Resource{
+				{ID: "unverifiable", Provider: model.ProviderRef{Name: "hyperv", AgentID: "agent-1"}},
+			},
+			remote:          map[model.ResourceID]remoteEntry{}, // hyperv wasn't listed at all
+			listedProviders: map[providersdk.Type]int{},         // empty: hyperv absent entirely
+		}
+		decision, err := eval.Evaluate(context.Background(), obs)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.ShouldAct {
+			t.Fatalf("expected no action for an unlisted provider type, got %+v", decision.Plan)
+		}
+	})
+
+	t.Run("safety valve: never reaps when a listed provider type came back suspiciously empty", func(t *testing.T) {
+		obs := reconcileObserved{
+			agentID: "agent-1",
+			tracked: []model.Resource{
+				{ID: "res-a", Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"}},
+				{ID: "res-b", Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"}},
+			},
+			remote:          map[model.ResourceID]remoteEntry{},
+			listedProviders: map[providersdk.Type]int{"docker": 0}, // listed successfully, but zero results
+		}
+		decision, err := eval.Evaluate(context.Background(), obs)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.ShouldAct {
+			t.Fatalf("expected the safety valve to suppress reaping, got %+v", decision.Plan)
+		}
+	})
+
+	t.Run("noop when everything already agrees", func(t *testing.T) {
+		obs := reconcileObserved{
+			agentID: "agent-1",
+			tracked: []model.Resource{
+				{ID: "res-a", Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"}},
+			},
+			remote: map[model.ResourceID]remoteEntry{
+				"res-a": {provider: "docker", status: providersdk.ResourceStatus{ID: "res-a", State: "running"}},
+			},
+			listedProviders: map[providersdk.Type]int{"docker": 1},
+		}
+		decision, err := eval.Evaluate(context.Background(), obs)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.ShouldAct {
+			t.Fatalf("expected noop, got %+v", decision.Plan)
+		}
+	})
+}
+
+// --- ReconcileAgent: end-to-end against a real MemoryStore/AgentRegistry ---
+
+// fakeListingAgent is a minimal agentsdk.Agent + agentsdk.ResourceListingAgent
+// test double. Unlike mockAgent (provisioner_agent_test.go), it exists
+// specifically to control List's per-provider-type results/errors.
+type fakeListingAgent struct {
+	info        agentsdk.AgentInfo
+	listResults map[providersdk.Type][]providersdk.ResourceStatus
+	listErrs    map[providersdk.Type]error
+}
+
+func (a *fakeListingAgent) Info() agentsdk.AgentInfo { return a.info }
+func (a *fakeListingAgent) Create(context.Context, providersdk.Type, any) (*providersdk.Resource, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeListingAgent) Read(context.Context, providersdk.Type, string) (*providersdk.ResourceStatus, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeListingAgent) Update(context.Context, providersdk.Type, string, providersdk.Operation) (*providersdk.Result, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeListingAgent) Delete(context.Context, providersdk.Type, string) error {
+	return errors.New("not implemented")
+}
+func (a *fakeListingAgent) Allocate(context.Context, providersdk.Type, string) (map[string]any, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeListingAgent) List(_ context.Context, provider providersdk.Type) ([]providersdk.ResourceStatus, error) {
+	if err, ok := a.listErrs[provider]; ok {
+		return nil, err
+	}
+	return a.listResults[provider], nil
+}
+
+// fakeNonListingAgent implements agentsdk.Agent only, deliberately missing
+// List — for exercising ReconcileAgent's behavior against an agent whose
+// driver(s) don't support enumeration at all. Not a fakeListingAgent
+// embedding (that would promote List and defeat the point).
+type fakeNonListingAgent struct {
+	info agentsdk.AgentInfo
+}
+
+func (a *fakeNonListingAgent) Info() agentsdk.AgentInfo { return a.info }
+func (a *fakeNonListingAgent) Create(context.Context, providersdk.Type, any) (*providersdk.Resource, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeNonListingAgent) Read(context.Context, providersdk.Type, string) (*providersdk.ResourceStatus, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeNonListingAgent) Update(context.Context, providersdk.Type, string, providersdk.Operation) (*providersdk.Result, error) {
+	return nil, errors.New("not implemented")
+}
+func (a *fakeNonListingAgent) Delete(context.Context, providersdk.Type, string) error {
+	return errors.New("not implemented")
+}
+func (a *fakeNonListingAgent) Allocate(context.Context, providersdk.Type, string) (map[string]any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestReconcileAgent_AdoptsOrphanAcrossStoreAndRegistry(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	agent := &fakeListingAgent{
+		info: agentsdk.AgentInfo{ID: "agent-1", Providers: []providersdk.Type{"docker"}},
+		listResults: map[providersdk.Type][]providersdk.ResourceStatus{
+			"docker": {{ID: "orphan-1", State: "running"}},
+		},
+	}
+	registry := registryWith(t, agent)
+
+	if err := ReconcileAgent(ctx, st, registry, "agent-1", slog.Default()); err != nil {
+		t.Fatalf("ReconcileAgent: %v", err)
+	}
+
+	res, err := st.GetResource(ctx, "orphan-1")
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+	if res.Provider.AgentID != "agent-1" || res.Provider.Name != "docker" {
+		t.Errorf("unexpected provider ref: %+v", res.Provider)
+	}
+	if res.State != model.ResourceStateUnknown {
+		t.Errorf("expected State=Unknown for an adopted orphan, got %v", res.State)
+	}
+}
+
+func TestReconcileAgent_ReapsConfirmedGoneResource(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	if err := st.PutResource(ctx, model.Resource{
+		ID:       "gone-1",
+		Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"},
+		State:    model.ResourceStateReady,
+	}); err != nil {
+		t.Fatalf("seed PutResource: %v", err)
+	}
+	// A second docker resource under the same provider type keeps the list
+	// non-empty, so the safety valve doesn't suppress the reap.
+	if err := st.PutResource(ctx, model.Resource{
+		ID:       "still-here",
+		Provider: model.ProviderRef{Name: "docker", AgentID: "agent-1"},
+		State:    model.ResourceStateReady,
+	}); err != nil {
+		t.Fatalf("seed PutResource: %v", err)
+	}
+
+	agent := &fakeListingAgent{
+		info: agentsdk.AgentInfo{ID: "agent-1", Providers: []providersdk.Type{"docker"}},
+		listResults: map[providersdk.Type][]providersdk.ResourceStatus{
+			"docker": {{ID: "still-here", State: "running"}},
+		},
+	}
+	registry := registryWith(t, agent)
+
+	if err := ReconcileAgent(ctx, st, registry, "agent-1", slog.Default()); err != nil {
+		t.Fatalf("ReconcileAgent: %v", err)
+	}
+
+	res, err := st.GetResource(ctx, "gone-1")
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+	if res.State != model.ResourceStateDestroyed {
+		t.Errorf("expected gone-1 to be marked Destroyed, got %v", res.State)
+	}
+
+	stillHere, err := st.GetResource(ctx, "still-here")
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+	if stillHere.State != model.ResourceStateReady {
+		t.Errorf("expected still-here to be untouched, got %v", stillHere.State)
+	}
+}
+
+func TestReconcileAgent_SkipsAuditForUnlistableProvider(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	if err := st.PutResource(ctx, model.Resource{
+		ID:       "vm-1",
+		Provider: model.ProviderRef{Name: "hyperv", AgentID: "agent-1"},
+		State:    model.ResourceStateReady,
+	}); err != nil {
+		t.Fatalf("seed PutResource: %v", err)
+	}
+
+	agent := &fakeListingAgent{
+		info: agentsdk.AgentInfo{ID: "agent-1", Providers: []providersdk.Type{"hyperv"}},
+		listErrs: map[providersdk.Type]error{
+			"hyperv": errors.New("list not supported by driver \"hyperv\""),
+		},
+	}
+	registry := registryWith(t, agent)
+
+	if err := ReconcileAgent(ctx, st, registry, "agent-1", slog.Default()); err != nil {
+		t.Fatalf("ReconcileAgent: %v", err)
+	}
+
+	res, err := st.GetResource(ctx, "vm-1")
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+	if res.State != model.ResourceStateReady {
+		t.Errorf("expected vm-1 to be untouched when its provider can't be listed, got %v", res.State)
+	}
+}
+
+func TestReconcileAgent_NoResourceListingCapability(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	agent := &fakeNonListingAgent{
+		info: agentsdk.AgentInfo{ID: "agent-1", Providers: []providersdk.Type{"docker"}},
+	}
+	registry := registryWith(t, agent)
+
+	// Must not error even though this agent can't be audited at all.
+	if err := ReconcileAgent(ctx, st, registry, "agent-1", slog.Default()); err != nil {
+		t.Fatalf("ReconcileAgent: %v", err)
+	}
+}
+
+func TestReconcileAgent_UnregisteredAgentErrors(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	registry := NewAgentRegistry()
+
+	if err := ReconcileAgent(ctx, st, registry, "does-not-exist", slog.Default()); err == nil {
+		t.Fatal("expected an error for an unregistered agent")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ReconcileAgent` in `internal/pool/reconcile.go`, built on `pkg/policycontroller.Controller`: adopts orphaned resources and reaps confirmed-gone ones. State-sync is deliberately out of scope — there's no existing driver-state-string→`model.ResourceState` mapping convention to build on.
- Includes a safety valve against suspiciously-empty listings, consistent with the stack-wide convention that a failed/untrustworthy `List` is never distinguished by cause and is always treated as "don't trust this pass."
- Wires the sweep into `agentserver.Server.Connect`: runs in a bounded (30s), best-effort goroutine after `remote.Serve()` starts, on every registration (not just reconnects).

## Test plan
- [x] Evaluator table tests for the reconciliation policy logic
- [x] End-to-end `MemoryStore`/`AgentRegistry` tests
- [x] `TestConnect_TriggersReconciliationSweep` — full gRPC round-trip
- [x] `golangci-lint run` clean locally

Stacked on #140 (List plumbing) — base branch is `feat/133-reconnect-reconciliation-sweep`, not `main`.